### PR TITLE
Added support for Dust (#8)

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -82,6 +82,25 @@ exports.jade = function(path, options, fn){
 };
 
 /**
+ * Dust support.
+ */
+
+exports.dust = function(path, options, fn){
+  var engine = requires.dust || (requires.dust = require('dust'));
+  read(path, options, function(err, str) {
+    if (err) return fn(err);
+    try {
+      options.filename = path;
+      engine.renderSource(str, options, function(err, tmpl) {
+        fn(err, tmpl);
+      });
+    } catch (err) {
+      fn(err);
+    }
+  });
+};
+
+/**
  * Swig support.
  */
 


### PR DESCRIPTION
Added support for Dust rendering: https://github.com/visionmedia/consolidate.js/issues/8

I have not done extensive testing, but works with the examples from their homepage:

**index.dust**
`Hello {name}! You have {count} new messages.`

**Code:**

``` javascript
var c = require('consolidate');
c.dust('path/to/index.dust', {"name": "foobar", "count": 5}, function(err, html) {
    console.log(html);
});
```

**Output:**
`Hello foobar! You have 5 new messages.`

On a side note, the latest version of Dust does not seem to work with newer Node as it uses require.paths, there's a fork that I used instead: https://github.com/semanticprogrammer/dustjs.git
