### PR TITLE
Swig does not support initialization

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -118,6 +118,11 @@ exports.swig = function(path, options, fn){
   });
 };
 
+exports.swig.init = function(options) {
+	var engine = requires.swig || (requires.swig = require('swig'));
+	engine.init(options);
+};
+
 /**
  * Liquor support,
  */


### PR DESCRIPTION
I might be doing this wrong, but I needed template inheritance in Swig and I didn't see a way to do it in consolidate via express 3.x

The way I solved this is to provide an init function to cons.swig so that I can pass in the root param. I don't think this is necessarily the best way to do this, but it seems to solve my problem for now. I bet you want to abstract this out to a pattern that all engines can use, but I'm not sure what's the best way to do it.

For now, this is my suggestion.
