### PR TITLE
Adding dust partial support

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -86,10 +86,12 @@ exports.jade = function(path, options, fn){
  */
 
 exports.dust = function(path, options, fn){
-  var engine = requires.dust || (requires.dust = require('dust'));
+  var engine = requires.dust;
 
-  // get dust partials to read from disk rather than from the (initially empty) dust cache
-  engine.onLoad = function( path, callback ) { read( path, options, callback ); }
+  if( !engine ) {
+    engine = requires.dust = require('dust');
+    engine.onLoad = function(path, callback) { read(path, options, callback); }
+  }
 
   read(path, options, function(err, str) {
     if (err) return fn(err);


### PR DESCRIPTION
I was unsure if there was a better place to put this.

For dust partials to render properly they must be already in the cache or you must specify a dust.onLoad function. Without a dust.onLoad function specified if you try to use a partial you receive a "template not found" error.

This sets dust.onLoad as the read function so that if the partial is not already in the dust cache it will load it from disk and add it to the dust cache.
