### PR TITLE
Support for LinkedIn's fork of Dust.js

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -89,7 +89,12 @@ exports.dust = function(path, options, fn){
   var engine = requires.dust;
 
   if (!engine) {
-    engine = requires.dust = require('dust');
+    try {
+      requires.dust = require('dust');
+    } catch (err) {
+      requires.dust = require('dustjs-linkedin');
+    }
+    engine = requires.dust;
     engine.onLoad = function(path, callback) { read(path, options, callback); }
   }
 


### PR DESCRIPTION
Since Dust.js development has been paused, and LinkedIn has provided a fork on it under a different NPM package, I put a try-catch to load the available package for Dust.js.
