### PR TITLE
Added partials loading for whiskers

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -244,13 +244,31 @@ exports.haml = function(path, options, fn){
 
 exports.whiskers = function(path, options, fn){
   var engine = requires.whiskers || (requires.whiskers = require('whiskers'));
-  read(path, options, function(err, str){
-    if (err) return fn(err);
+  var keys = options.partials ? Object.keys(options.partials) : [];
+  var pending = keys.length + 1; // +1 for the view
+  var view;
+  function render() {
     try {
-      fn(null, engine.render(str, options));
+      fn(null, engine.render(view, options));
     } catch (err) {
       fn(err);
     }
+  };
+
+  // load partials
+  keys.forEach(function(key){
+    read(require('path').join(options.settings.views, options.partials[key]), options, function(err, str){
+      if (err) return fn(err);
+      options.partials[key] = str;
+      --pending || render();
+    });
+  });
+
+  // load view
+  read(path, options, function(err, str){
+    if (err) return fn(err);
+    view = str;
+    --pending || render();
   });
 };
 


### PR DESCRIPTION
Whiskers doesn't handle file loading in the view itself, so it
needs partials to be loaded into the options. This patch does
so for any view name in options.partials. Something similar could
be useful for other templating systems if it could be exposed in
some way by Express.
