### PR TITLE
Make non-engine exports unenumerable

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -3,7 +3,7 @@
  * consolidate
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>
  * MIT Licensed
- * 
+ *
  * Engines which do not support caching of their file contents
  * should use the `read()` function defined in consolidate.js
  * On top of this, when an engine compiles to a `Function`,
@@ -24,7 +24,7 @@ var fs = require('fs');
  * Library version.
  */
 
-exports.version = '0.2.0';
+Object.defineProperty(exports, 'version', {value: '0.0.2'});
 
 /**
  * Require cache.
@@ -44,9 +44,11 @@ var requires = {};
  * @api public
  */
 
-exports.clearCache = function(){
-  cache = {};
-};
+Object.defineProperty(exports, 'clearCache', {
+  value: function(){
+    cache = {};
+  }
+});
 
 /**
  * Read `path` with `options` with


### PR DESCRIPTION
The use case:
  This can facilitate writing of toy apps, for example 

``` javascript
app.use(serveViews('dir/with/views', consolidate))
```

Then if request's path is '/hello.jade' it will render hello.jade and so on for any known engine. If new engine comes in we do not need to update setup to play with it.
