### PR TITLE
Disable Dust.js caching for partials in development environment.

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1,4 +1,3 @@
-
 /*!
  * consolidate
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>
@@ -102,6 +101,7 @@ exports.dust = function(path, options, fn){
     if (err) return fn(err);
     try {
       options.filename = path;
+      if (!options.cache) engine.cache = {};
       engine.renderSource(str, options, function(err, tmpl) {
         fn(err, tmpl);
       });


### PR DESCRIPTION
In development environment, main templates are not cached, but the partials were.
We clear out the dust.cache in this environment to disable it.
