### PR TITLE
Support inheritance and partials in QEJS

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -322,20 +322,15 @@ exports.underscore = function(path, options, fn) {
  * QEJS support.
  */
 
-exports.qejs = function(path, options, fn){
-  var engine = requires.qejs || (requires.qejs = require('qejs'));
-  read(path, options, function(err, str){
-    if (err) return fn(err);
-    try {
-      options.filename = path;
-      var tmpl = engine.compile(str, options);
-      tmpl(options).then(function(result){
+exports.qejs = function (path, options, fn) {
+  try {
+    var engine = requires.qejs || (requires.qejs = require('qejs'));
+    engine.renderFile(path, options).then(function (result) {
         fn(null, result);
-      },function(err){
+    }, function (err) {
         fn(err);
-      }).end();
-    } catch (err) {
-      fn(err);
-    }
-  });
+    }).end();
+  } catch (err) {
+    fn(err);
+  }
 };


### PR DESCRIPTION
The latest version of QEJS supports inheritance and partials.  It's documented in the [readme](https://github.com/jepso/QEJS) but it's only supported through the `renderFile` interface.

This also offers a simpler syntax since QEJS already supports caching via its renderFile operation.

Tests still pass.
