### PR TITLE
Dust.js Template-function Caching

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -55,8 +55,8 @@ exports.clearCache = function(){
 function read(path, options, fn) {
   var str = cache[path];
 
-  // cached
-  if (options.cache && str) return fn(null, str);
+  // cached (only if cached is a string and not a compiled template function)
+  if (options.cache && str && typeof str === 'string') return fn(null, str);
 
   // read
   fs.readFile(path, 'utf8', function(err, str){
@@ -92,18 +92,31 @@ exports.dust = function(path, options, fn){
     engine.onLoad = function(path, callback) { read(path, options, callback); }
   }
 
-  read(path, options, function(err, str) {
-    if (err) return fn(err);
-    try {
-      options.filename = path;
-      if (!options.cache) engine.cache = {};
-      engine.renderSource(str, options, function(err, tmpl) {
-        fn(err, tmpl);
-      });
-    } catch (err) {
-      fn(err);
-    }
-  });
+  var tmpl = cache[path];
+
+  // try cache (only if cached is a compiled template function and not a string)
+  if (options.cache && tmpl && typeof tmpl === 'function') {
+    tmpl(options, function(err, out) {
+      fn(err, out);
+    });
+  } else {
+    read(path, options, function(err, str) {
+      if (err) return fn(err);
+      try {
+        options.filename = path;
+        tmpl = engine.compileFn(str);
+        
+        if (options.cache) cache[path] = tmpl;
+        else engine.cache = {};
+        
+        tmpl(options, function(err, out) {
+          fn(err, out);
+        });
+      } catch (err) {
+        fn(err);
+      }
+    });
+  }
 };
 
 /**


### PR DESCRIPTION
At the beginning of the consolidate.js file, a comment states "On top of this, when an engine compiles to a 'Function', these functions should either be cached within consolidate.js or the engine itself via 'options.cache'."

So this template-function caching is a stated goal of Consolidate, but as far as I can tell it hasn't been implemented.  Well, at least for Dust.js it definitely hasn't.  Dust has no internal caching, and Consolidate provides no template-function caching, so the templates are recompiled on each call (the renderSource() method currently used calls compileFn() internally in Dust.js).

This commit provides 1) a quick fix for the cache to store both functions and strings without mixing them up, and 2) template-function caching for Dust.js.

I implemented the template-function caching outside of the read() method to keep that from causing problems with backwards-compatibility, and also left the string caching intact to handle edge cases like a cache access before the function compile/cache finishes.

Let me know if there's anything I need to fix.
