### PR TITLE
Add npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "qejs": "0.0.1",
     "walrus": "0.9.0"
   },
-  "main": "index"
+  "main": "index",
+  "scripts": {
+    "test": "mocha"
+  }
 }


### PR DESCRIPTION
This way anyone can simply run `npm install` then `npm test` to run all the tests.  This is particularly important for people who may not have mocha installed, but it's helpful in general for getting people started on running tests quickly.
