### PR TITLE
Improve Haml-Coffee caching

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -3,7 +3,7 @@
  * consolidate
  * Copyright(c) 2012 TJ Holowaychuk <tj@vision-media.ca>
  * MIT Licensed
- * 
+ *
  * Engines which do not support caching of their file contents
  * should use the `read()` function defined in consolidate.js
  * On top of this, when an engine compiles to a `Function`,
@@ -257,15 +257,28 @@ exports.whiskers = function(path, options, fn){
 
 exports['haml-coffee'] = function(path, options, fn){
   var engine = requires.HAMLCoffee || (requires.HAMLCoffee = require('haml-coffee'));
-  read(path, options, function(err, str){
-    if (err) return fn(err);
+  var tmpl = cache[path];
+
+  // try cache (only if cached is a compiled template function and not a string)
+  if (options.cache && tmpl && 'function' == typeof tmpl) {
     try {
-      var tmpl = engine.compile(str, options);
-      fn(null, tmpl(options));
+      var html = tmpl(options);
+      fn(null, html);
     } catch (err) {
       fn(err);
     }
-  });
+  } else {
+    read(path, options, function(err, str) {
+      if (err) return fn(err);
+      try {
+        var tmpl = engine.compile(str, options);
+        cache[path] = tmpl;
+        fn(null, tmpl(options));
+      } catch (err) {
+        fn(err);
+      }
+    });
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "liquor": "0.0.4",
     "hamljs": "0.6.1",
     "whiskers": "0.2.2",
-    "haml-coffee": "0.6.3",
+    "haml-coffee": "1.4.0",
     "hogan.js": "2.0.0",
     "dust": "0.3.0",
     "dustjs-linkedin": "0.4.0",


### PR DESCRIPTION
Change the Haml-Coffee caching to cache the precompiled template
function instead only the template source code to improve subsequent
template renderings, similar to doT.
