### PR TITLE
Render templates from string synchronously

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -111,6 +111,10 @@ exports.jade = function(path, options, fn){
  */
 
 exports.jade.render = function(str, options, fn){
+  if (!fn) {
+    throw new Error('Jade does not support synchronous rendering');
+  }
+
   var engine = requires.jade || (requires.jade = require('jade'));
   engine.render(str, options, fn);
 };
@@ -126,6 +130,10 @@ exports.dust = fromStringRenderer('dust');
  */
 
 exports.dust.render = function(str, options, fn){
+  if (!fn) {
+    throw new Error('Dust does not support synchronous rendering');
+  }
+
   var engine = requires.dust;
   if (!engine) {
     try {
@@ -156,10 +164,20 @@ exports.swig = fromStringRenderer('swig');
 exports.swig.render = function(str, options, fn){
   var engine = requires.swig || (requires.swig = require('swig'));
   try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
+    var tmpl = cache(options) || cache(options, engine.compile(str, options)),
+        rendered = tmpl(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -176,10 +194,20 @@ exports.liquor = fromStringRenderer('liquor');
 exports.liquor.render = function(str, options, fn){
   var engine = requires.liquor || (requires.liquor = require('liquor'));
   try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
+    var tmpl = cache(options) || cache(options, engine.compile(str, options)),
+        rendered = tmpl(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -197,9 +225,19 @@ exports.ejs.render = function(str, options, fn){
   var engine = requires.ejs || (requires.ejs = require('ejs'));
   try {
     var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
+        rendered = tmpl(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -217,9 +255,19 @@ exports.eco = fromStringRenderer('eco');
 exports.eco.render = function(str, options, fn){
   var engine = requires.eco || (requires.eco = require('eco'));
   try {
-    fn(null, engine.render(str, options));
+    var rendered = engine.render(str, options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -234,6 +282,10 @@ exports.jazz = fromStringRenderer('jazz');
  */
 
 exports.jazz.render = function(str, options, fn){
+  if (!fn) {
+    throw new Error('Jazz does not support synchronous rendering');
+  }
+
   var engine = requires.jazz || (requires.jazz = require('jazz'));
   try {
     var tmpl = cache(options) || cache(options, engine.compile(str, options));
@@ -259,9 +311,19 @@ exports.jqtpl.render = function(str, options, fn){
   var engine = requires.jqtpl || (requires.jqtpl = require('jqtpl'));
   try {
     engine.template(str, str);
-    fn(null, engine.tmpl(str, options));
+    var rendered = engine.tmpl(str, options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -279,9 +341,19 @@ exports.haml.render = function(str, options, fn){
   var engine = requires.hamljs || (requires.hamljs = require('hamljs'));
   try {
     options.locals = options;
-    fn(null, engine.render(str, options).trimLeft());
+    var rendered = engine.render(str, options).trimLeft();
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -301,9 +373,19 @@ exports.whiskers = function(path, options, fn){
 exports.whiskers.render = function(str, options, fn){
   var engine = requires.whiskers || (requires.whiskers = require('whiskers'));
   try {
-    fn(null, engine.render(str, options));
+    var rendered = engine.render(str, options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -320,10 +402,20 @@ exports['haml-coffee'] = fromStringRenderer('haml-coffee');
 exports['haml-coffee'].render = function(str, options, fn){
   var engine = requires.HAMLCoffee || (requires.HAMLCoffee = require('haml-coffee'));
   try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
+    var tmpl = cache(options) || cache(options, engine.compile(str, options)),
+        rendered = tmpl(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -340,10 +432,20 @@ exports.hogan = fromStringRenderer('hogan');
 exports.hogan.render = function(str, options, fn){
   var engine = requires.hogan || (requires.hogan = require('hogan.js'));
   try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl.render(options));
+    var tmpl = cache(options) || cache(options, engine.compile(str, options)),
+        rendered = tmpl.render(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -360,12 +462,22 @@ exports.handlebars = fromStringRenderer('handlebars');
 exports.handlebars.render = function(str, options, fn) {
   var engine = requires.handlebars || (requires.handlebars = require('handlebars'));
   try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
+    var tmpl = cache(options) || cache(options, engine.compile(str, options)),
+        rendered = tmpl(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
-}
+};
 
 /**
  * Underscore support.
@@ -380,10 +492,20 @@ exports.underscore = fromStringRenderer('underscore');
 exports.underscore.render = function(str, options, fn) {
   var engine = requires.underscore || (requires.underscore = require('underscore'));
   try {
-    var tmpl = cache(options) || cache(options, engine.template(str, null, options));
-    fn(null, tmpl(options).replace(/\n$/, ''));
+    var tmpl = cache(options) || cache(options, engine.template(str, null, options)),
+        rendered = tmpl(options).replace(/\n$/, '');
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -410,6 +532,10 @@ exports.qejs = function (path, options, fn) {
  */
 
 exports.qejs.render = function (str, options, fn) {
+  if (!fn) {
+    throw new Error('QEJS does not support synchronous rendering');
+  }
+
   try {
     var engine = requires.qejs || (requires.qejs = require('qejs'));
     engine.render(str, options).then(function (result) {
@@ -436,10 +562,20 @@ exports.walrus = fromStringRenderer('walrus');
 exports.walrus.render = function (str, options, fn) {
   var engine = requires.walrus || (requires.walrus = require('walrus'));
   try {
-    var tmpl = cache(options) || cache(options, engine.parse(str));
-    fn(null, tmpl.compile(options));
+    var tmpl = cache(options) || cache(options, engine.parse(str)),
+        rendered = tmpl.compile(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -456,9 +592,19 @@ exports.mustache = fromStringRenderer('mustache');
 exports.mustache.render = function(str, options, fn) {
   var engine = requires.mustache || (requires.mustache = require('mustache'));
   try {
-    fn(null, engine.to_html(str, options));
+    var rendered = engine.to_html(str, options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      return fn;
+    }
   }
 };
 
@@ -475,10 +621,20 @@ exports.dot = fromStringRenderer('dot');
 exports.dot.render = function(str, options, fn) {
   var engine = requires.dot || (requires.dot = require('dot'));
   try {
-    var tmpl = cache(options) || cache(options, engine.template(str));
-    fn(null, tmpl(options));
+    var tmpl = cache(options) || cache(options, engine.template(str)),
+        rendered = tmpl(options);
+
+    if (fn) {
+      fn(null, rendered);
+    } else {
+      return rendered;
+    }
   } catch (err) {
-    fn(err);
+    if (fn) {
+      fn(err);
+    } else {
+      throw err;
+    }
   }
 };
 
@@ -501,6 +657,10 @@ exports.just = function(path, options, fn){
  */
 
 exports.just.render = function(str, options, fn){
+  if (!fn) {
+    throw new Error('JUST does not support synchronous rendering');
+  }
+
   var JUST = require('just');
   var engine = new JUST({ root: { page: str }});
   engine.render('page', options, fn);


### PR DESCRIPTION
Is there currently any way to render templates given a string and not a filename? If not, would you consider adding this? I'm willing to lend a hand with the implementation :) Basically I would like to add consolidate support to another library, but it deals with template strings, not files.
