### PR TITLE
Invalidates built-in dust cache if caching disabled

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -212,6 +212,7 @@ exports.dust.render = function(str, options, fn){
     if (options.views) views = options.views;
     if (options.settings && options.settings.views) views = options.settings.views;
   }
+  if (!options || (options && !options.cache)) engine.cache = {};
 
   engine.onLoad = function(path, callback){
     if ('' == extname(path)) path += '.' + ext;


### PR DESCRIPTION
My problem: Dust checks it's internal cache before calling dust.onLoad which has the effect that any template included within another template gets automatically cached and setting options.cache has no effect on the internal dust cache.

For example, if you have:

index.dust

```
{>"layout"/}

{<body}
  my index body
{/body}
```

and layout.dust

```
<html>
  <head>
    <title>example</title>
  </head>
  <body>
    {+body/}
  </body>
</html>
```

If you view index, then add something to layout.dust after having viewed index once, you will have to restart the server to see your change to layout reflected.

Ideally I would be able to modify the `dust.register` function, but I don't see how to do that since dust always tries to read from `dust.cache`.

This was the best solution I could come up with, any other suggestions?
