### PR TITLE
Export read function

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -77,7 +77,7 @@ function cache(options, compiled) {
  * @api public
  */
 
-var read = exports.read = function read(path, options, fn) {
+exports.read = function read(path, options, fn) {
   var str = readCache[path];
 
   // cached (only if cached is a string and not a compiled template function)
@@ -101,7 +101,7 @@ function fromStringRenderer(name) {
     if (cache(options)) {
       exports[name].render('', options, fn);
     } else {
-      read(path, options, function(err, str){
+      exports.read(path, options, function(err, str){
         if (err) return fn(err);
         exports[name].render(str, options, fn);
       });
@@ -158,7 +158,7 @@ exports.dust.render = function(str, options, fn){
   engine.onLoad = function(path, callback){
     if ('' == extname(path)) path += '.' + ext;
     if ('/' !== path[0]) path = views + '/' + path;
-    read(path, options, callback);
+    exports.read(path, options, callback);
   };
 
   try {


### PR DESCRIPTION
This would allow the developer to override the`read` function, enabling you to load your views in different ways, i.e. multiple directories, databases, cdn, etc.

``` js
var read = consolidate.read;

consolidate.read = function(path, options, fn) {
  // custom path lookup
  read(path, options, fn);
};
```
