### PR TITLE
Add `then-jade` as an alternative `jade` implementation

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -153,7 +153,14 @@ function fromStringRenderer(name) {
  */
 
 exports.jade = function(path, options, fn){
-  var engine = requires.jade || (requires.jade = require('jade'));
+  var engine = requires.jade;
+  if (!engine) {
+    try {
+      engine = requires.jade = require('jade');
+    } catch (err) {
+      engine = requires.jade = require('then-jade');
+    }
+  }
   engine.renderFile(path, options, fn);
 };
 


### PR DESCRIPTION
`then-jade` is built to be a drop in replacement for `jade`. It is almost identical but for the fact that it supports asynchronous filters. As such it can use any of the consolidate template libraries as filters (in addition to filters for markdown, coffee-script etc.). I've aimed to match what the other libraries do when there's more than one supported implementation. I also left jade as the first one that's looked for as that should suit the majority of people.
