### PR TITLE
Partials ignore express' views folder

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -109,6 +109,7 @@ function read(path, options, fn) {
  */
 
 function readPartials(path, options, fn) {
+  var partialsPath = options && options.settings && options.settings.views || dirname(path);
   if (!options.partials) return fn();
   var partials = options.partials;
   var keys = Object.keys(partials);
@@ -116,7 +117,7 @@ function readPartials(path, options, fn) {
   function next(index) {
     if (index == keys.length) return fn(null);
     var key = keys[index];
-    var file = join(dirname(path), partials[key] + extname(path));
+    var file = join(partialsPath, partials[key] + extname(path));
     read(file, options, function(err, str){
       if (err) return fn(err);
       options.partials[key] = str;


### PR DESCRIPTION
Following situation:

**Appfolder/app.js:**

```
app.engine('html', cons.handlebars);
app.set('views', __dirname + '/views');

[...]
res.render('account/edit', {partials: {
  head: '_head'
}});
[...]
```

→ Consolidate looks for `Appfolder/views/account/_head.html` instead of `Appfolder/views/_head.html` which is the default views folder we defined earlier. 

This is in my eyes pretty unfavorable because we don't have a chance to define "default" partials using app.locals() since the folder consolidate is looking for templates differs for every view and depends on the folder the currently compiled template is placed in.

In my version consolidate checks if a default `views` folder was defined and if so, loads the partials from there instead of from the current path.

`app.locals({partials: {head: '_head'}});` then always looks for `Appfolder/views/_head.html` and ignores the current working dir which makes life much easier.
