### PR TITLE
Added support for Handlebars helpers with test.

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -483,6 +483,9 @@ exports.handlebars.render = function(str, options, fn) {
     for (var partial in options.partials) {
       engine.registerPartial(partial, options.partials[partial]);
     }
+    for (var helper in options.helpers) {
+      engine.registerHelper(helper, options.helpers[helper]);
+    }
     var tmpl = cache(options) || cache(options, engine.compile(str, options));
     fn(null, tmpl(options));
   } catch (err) {

--- a/test/consolidate.js
+++ b/test/consolidate.js
@@ -15,6 +15,7 @@ require('./shared').test('dust');
 require('./shared/partials').test('dust');
 require('./shared').test('handlebars');
 require('./shared/partials').test('handlebars');
+require('./shared/helpers').test('handlebars');
 require('./shared').test('underscore');
 require('./shared').test('qejs');
 require('./shared').test('walrus');

--- a/test/fixtures/handlebars/helpers.handlebars
+++ b/test/fixtures/handlebars/helpers.handlebars
@@ -1,0 +1,1 @@
+{{safe user.name}}

--- a/test/shared/helpers.js
+++ b/test/shared/helpers.js
@@ -1,0 +1,36 @@
+
+var cons = require('../../')
+  , handlebars = require('handlebars')
+  , fs = require('fs')
+  , readFile = fs.readFile
+  , readFileSync = fs.readFileSync;
+
+exports.test = function(name) {
+  var user = { name: '<strong>Tobi</strong>' };
+
+  describe(name, function(){
+
+    afterEach(function(){
+      fs.readFile = readFile;
+      fs.readFileSync = readFileSync;
+    });
+
+    if (name == 'handlebars') {
+
+      // Use case: return safe HTML that won’t be escaped in the final render.
+      it('should support helpers', function(done) {
+        var str = fs.readFileSync('test/fixtures/' + name + '/helpers.' + name).toString();
+
+        var locals = { user: user, helpers: { safe: function(object) {
+          return new handlebars.SafeString(object);
+        }}};
+
+        cons[name].render(str, locals, function(err, html){
+          if (err) return done(err);
+          html.should.equal('<strong>Tobi</strong>');
+          done();
+        });
+      });
+    }
+  });
+};


### PR DESCRIPTION
[Helpers](http://handlebarsjs.com/expressions.html#helpers) are required in Handlebars when returning safe strings, etc. Added support (same as partials) and a test.
