### PR TITLE
Support Teacup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,7 @@
   - [react](https://github.com/facebook/react)
   - [slm](https://github.com/slm-lang/slm)
   - [swig](https://github.com/paularmstrong/swig) [(website)](http://paularmstrong.github.com/swig/)
+  - [teacup](https://github.com/goodeggs/teacup)
   - [templayed](http://archan937.github.com/templayed.js/)
   - [twig](https://github.com/justjohn/twig.js)
   - [liquid](https://github.com/leizongmin/tinyliquid) [(website)](http://liquidmarkup.org/)

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1191,20 +1191,20 @@ function reactBaseTmpl(data, options){
  *  The main render parser for React bsaed templates
  */
 function reactRenderer(type){
-  
+
   if (require.extensions) {
-  
+
     // Ensure JSX is transformed on require
     if (!require.extensions['.jsx']) {
       require.extensions['.jsx'] = requireReact;
     }
-  
+
     // Supporting .react extension as well as test cases
     // Using .react extension is not recommended.
     if (!require.extensions['.react']) {
       require.extensions['.react'] = requireReact;
     }
-    
+
   }
 
   // Return rendering fx
@@ -1367,7 +1367,44 @@ exports.slm.render = function(str, options, fn) {
 };
 
 /**
+ * Teacup support.
+ */
+exports.teacup = function(path, options, fn) {
+  return promisify(fn, function(fn) {
+    var engine = requires.teacup || (requires.teacup = require('teacup/lib/express'));
+    require.extensions['.teacup'] = require.extensions['.coffee'];
+    if (path[0] != '/') {
+      path = join(process.cwd(), path);
+    }
+    if (!options.cache) {
+      var originalFn = fn;
+      fn = function() {
+        delete require.cache[path];
+        originalFn.apply(this, arguments);
+      };
+    }
+    engine.renderFile(path, options, fn);
+  });
+};
+
+/**
+ * Teacup string support.
+ */
+exports.teacup.render = function(str, options, fn){
+  var coffee = require('coffee-script');
+  var vm = require('vm');
+  var sandbox = {
+    module: {exports: {}},
+    require: require
+  };
+  return promisify(fn, function(fn) {
+    vm.runInNewContext(coffee.compile(str), sandbox);
+    var tmpl = sandbox.module.exports;
+    fn(null, tmpl(options));
+  });
+}
+
+/**
  * expose the instance of the engine
  */
-
-exports.requires = requires;
+ exports.requires = requires;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "arc-templates": "^0.5.1",
     "atpl": ">=0.7.6",
+    "coffee-script": "^1.11.1",
     "dot": "^1.0.1",
     "dust": "^0.3.0",
     "dustjs-helpers": "^1.1.1",
@@ -42,6 +43,7 @@
     "should": "*",
     "slm": "^0.5.0",
     "swig": "^1.4.1",
+    "teacup": "^2.0.0",
     "templayed": ">=0.2.3",
     "tinyliquid": "^0.2.22",
     "toffee": "^0.1.12",

--- a/test/consolidate.js
+++ b/test/consolidate.js
@@ -50,3 +50,4 @@ require('./shared').test('arc-templates');
 require('./shared/filters').test('arc-templates');
 require('./shared/includes').test('arc-templates');
 require('./shared/partials').test('arc-templates');
+require('./shared').test('teacup');

--- a/test/fixtures/teacup/user.teacup
+++ b/test/fixtures/teacup/user.teacup
@@ -1,0 +1,4 @@
+{renderable, p} = require 'teacup'
+
+module.exports = renderable ({user}) ->
+  p user.name


### PR DESCRIPTION
Descendant of coffeecup, requested in #103.

Disabling caching currently won't work for [helpers](https://github.com/goodeggs/teacup#helpers) since they use the Node require cache.  I could diff and purge the whole `module.cache` after each render, but that feels janky.  Better to just use node-supervisor and friends in development.
