### PR TITLE
Partials should be relative to views, not dirname(path)

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -116,7 +116,7 @@ function readPartials(path, options, fn) {
   function next(index) {
     if (index == keys.length) return fn(null);
     var key = keys[index];
-    var file = join(dirname(path), partials[key] + extname(path));
+    var file = join(options.settings.views, partials[key] + extname(path));
     read(file, options, function(err, str){
       if (err) return fn(err);
       options.partials[key] = str;


### PR DESCRIPTION
Partials are currently read relative to the dirname of the template
you're rendering, not the views directory.  This means that when you're
rendering views/subfolder/page  the partials in views/partials won't
load correctly.
