### PR TITLE
Allow custom defs to be passed through to doT.js compile.

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -696,7 +696,7 @@ exports.dot = fromStringRenderer('dot');
 exports.dot.render = function (str, options, fn) {
   var engine = requires.dot || (requires.dot = require('dot'));
   try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options._def));
+    var tmpl = cache(options) || cache(options, engine.compile(str, options && options._def));
     fn(null, tmpl(options));
   } catch (err) {
     fn(err);


### PR DESCRIPTION
'Pass down custom defines/external params to templates, which doT.js allows but using with Consolidate.JS currently stops.'  This is a small change.

The following example shows what is currently not possible, but this pull request fixes:

Example 1 (Using a def.loadfile param inside templates):

| - test.js
| - views/home.html
| - views/main.html

---

``` html
<!-- main.html -->
<html>
<body>
it.h at top of main.html = {{=it.h}}
<br/>
<br/>
{{#def.loadfile('./home.html')}}
</body>
<html>

<!-- home.html -->
<h1>it.h from within home.html = {{=it.h}}</h1>

```

---

``` js

var fs = require('fs');
var dot = require('consolidate').dot;
var express = require('express');
var server = express();
var VIEWS = __dirname + '/views/';

server.set('views', VIEWS);
server.set('view engine', 'html' );
server.engine('html', dot );

server.get('/', function root(req,res) {

  var _def = {
    loadfile: function(path) {
      return fs.readFileSync(VIEWS + path);
    }
  };

  // Do we really want to get and attach a _def property to all objects sent to .render?
  // Probably not - see example below using .locals to solve this.
  var options = {
    h: 'hi',
    _def: _def
  };

  res.render('main', options);
});
server.listen(8000);

```

localhost:8000/ returns:

``` html
<html>
<body>
it.h at top of main.html = hi
<br/>
<br/>
<h1>it.h from within home.html = hi</h1>
</body>
<html>
```

What if you do not want to pass _def to every options object for .render?  The Express .locals function works like a charm:

``` js
var fs = require('fs');
var dot = require('consolidate').dot;
var express = require('express');
var server = express();
var VIEWS = __dirname + '/views/';

server.set('views', VIEWS);
server.set('view engine', 'html' );
server.set('view cache', true );
server.locals({_def: {
  loadfile: function(path) {
    return fs.readFileSync(VIEWS + path);
  }
}});
server.engine('html', dot );

server.get('/', function root(req,res) {

  var options = {
    h: 'hi'
  };

  res.render('main', options);
});
server.listen(8000);
```

loadfile can now be used in all templates.

---

Example 2 (not using loadfile in the main template):

``` html
<!-- main.html -->
<html>
<body>
it.h at top of main.html = {{=it.h}}
<br/>
<br/>
{{#def.body || 'Some error message - no body?'}}
</body>
<html>

<!-- home.html -->
{{##def.body:
  <h1>it.h from within home.html = {{=it.h}}</h1>
#}}
{{#def.loadfile('./main.html')}}
<!-- Alternatively, pass down external snippet main.html as an extra _def. param, so there is no need to use .loadfile at the end of every template. -->

```

Update: added simple check to avoid any crashes if options is not defined or null.
