### PR TITLE
Removed extraneous utf-8 bom marker, when partials are read.

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -93,6 +93,8 @@ function read(path, options, fn) {
   // read
   fs.readFile(path, 'utf8', function(err, str){
     if (err) return fn(err);
+    // remove extraneous utf8 BOM marker
+    str = str.replace(/^\uFEFF/, '');
     if (options.cache) readCache[path] = str;
     fn(null, str);
   });


### PR DESCRIPTION
Fix for issue visionmedia/consolidate.js#124
