### PR TITLE
Fixed twig production cache setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
+.idea
 *.sock

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -243,6 +243,7 @@ exports.swig = fromStringRenderer('swig');
 exports.swig.render = function(str, options, fn){
   var engine = requires.swig || (requires.swig = require('swig'));
   try {
+    if(options.cache === true) options.cache = 'memory';
     var tmpl = cache(options) || cache(options, engine.compile(str, options));
     fn(null, tmpl(options));
   } catch (err) {


### PR DESCRIPTION
The twig template engine does not take a parameter 'true' for cache settings. Rather the equivalent is 'memory'. Thus until this fix is made all production twig configurations will fail.
