### PR TITLE
Falling back to express3-handlebars when installed

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -486,7 +486,14 @@ exports.handlebars = fromStringRenderer('handlebars');
  */
 
 exports.handlebars.render = function(str, options, fn) {
-  var engine = requires.handlebars || (requires.handlebars = require('handlebars'));
+  var engine = requires.handlebars;
+  if (!engine) {
+      try {
+          engine = requires.handlebars = require('handlebars');
+      } catch (err) {
+          engine = requires.handlebars = require('express3-handlebars');
+      }
+  }
   try {
     for (var partial in options.partials) {
       engine.registerPartial(partial, options.partials[partial]);
@@ -499,6 +506,33 @@ exports.handlebars.render = function(str, options, fn) {
   } catch (err) {
     fn(err);
   }
+}
+
+
+/**
+ * Handlebars3-express support.
+ */
+
+exports.hbs3express = fromStringRenderer('hbs3express');
+
+/**
+ * Handlebars string support.
+ */
+
+exports.hbs3express.render = function(str, options, fn) {
+    var engine = requires.handlebars || (requires.handlebars = require('handlebars'));
+    try {
+        for (var partial in options.partials) {
+            engine.registerPartial(partial, options.partials[partial]);
+        }
+        for (var helper in options.helpers) {
+            engine.registerHelper(helper, options.helpers[helper]);
+        }
+        var tmpl = cache(options) || cache(options, engine.compile(str, options));
+        fn(null, tmpl(options));
+    } catch (err) {
+        fn(err);
+    }
 }
 
 /**

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -508,33 +508,6 @@ exports.handlebars.render = function(str, options, fn) {
   }
 }
 
-
-/**
- * Handlebars3-express support.
- */
-
-exports.hbs3express = fromStringRenderer('hbs3express');
-
-/**
- * Handlebars string support.
- */
-
-exports.hbs3express.render = function(str, options, fn) {
-    var engine = requires.handlebars || (requires.handlebars = require('handlebars'));
-    try {
-        for (var partial in options.partials) {
-            engine.registerPartial(partial, options.partials[partial]);
-        }
-        for (var helper in options.helpers) {
-            engine.registerHelper(helper, options.helpers[helper]);
-        }
-        var tmpl = cache(options) || cache(options, engine.compile(str, options));
-        fn(null, tmpl(options));
-    } catch (err) {
-        fn(err);
-    }
-}
-
 /**
  * Underscore support.
  */


### PR DESCRIPTION
If handlebars is not found and express3-handlebars is, we fall back to that as a drop-in replacement for handlebars.