### PR TITLE
Throw error requiring jade in favor of then-jade

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -180,7 +180,11 @@ exports.jade.render = function(str, options, fn){
     try {
       engine = requires.jade = require('jade');
     } catch (err) {
-      engine = requires.jade = require('then-jade');
+      try {
+        engine = requires.jade = require('then-jade');
+      } catch (otherError) {
+        throw err;
+      }
     }
   }
   engine.render(str, options, fn);


### PR DESCRIPTION
"jade" is more popular (and more stable) than "then-jade", so we should encourage people to use that.  When neither "jade", nor "then-jade" are installed, consolidate currently throws an error asking for "then-jade".  This changes it so the error asks for "jade".

See https://github.com/balderdashy/sails/issues/1629 and https://github.com/then/then-jade/issues/9 for the confusion the error created.

P.S. I maintain "then-jade" and "jade", so have no personal bias to declare.
