### PR TITLE
Instantiate swig engine object with options

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -249,7 +249,12 @@ exports.swig = fromStringRenderer('swig');
  */
 
 exports.swig.render = function(str, options, fn){
-  var engine = requires.swig || (requires.swig = require('swig'));
+  var engine = requires.swig || null;
+  if (!requires.swig) {
+    var swig = require('swig');
+    engine = requires.swig = new swig.Swig(options);
+  }
+
   try {
     if(options.cache === true) options.cache = 'memory';
     var tmpl = cache(options) || cache(options, engine.compile(str, options));

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -249,13 +249,13 @@ exports.swig = fromStringRenderer('swig');
  */
 
 exports.swig.render = function(str, options, fn){
-  var engine = requires.swig || null;
-  if (!requires.swig) {
-    var swig = require('swig');
-    engine = requires.swig = new swig.Swig(options);
-  }
-
   try {
+    var engine = requires.swig || null;
+    if (!requires.swig) {
+      var swig = require('swig');
+      engine = requires.swig = new swig.Swig(options);
+    }
+
     if(options.cache === true) options.cache = 'memory';
     var tmpl = cache(options) || cache(options, engine.compile(str, options));
     fn(null, tmpl(options));


### PR DESCRIPTION
Settings were not propagated, such as cache settings.