### PR TITLE
Pass express 'views' setting to nunjucks (fix #151)

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -762,5 +762,6 @@ exports.nunjucks = fromStringRenderer('nunjucks');
 
 exports.nunjucks.render = function(str, options, fn) {
   var engine = requires.nunjucks || (requires.nunjucks = require('nunjucks'));
+  options.settings && engine.configure(options.settings.views);
   engine.renderString(str, options, fn);
 };


### PR DESCRIPTION
**Problem:**

Consolidate is not properly setting Nunjucks' environment to look for templates in options.settings.views. This means that template inheritance is entirely broken when using nunjucks via consolidate in express.

**Solution:**

If express options exist, set the Nunjucks environment when calling `render`. Internally, the Nunjucks environment is a singleton, so this should not affect performance.