### PR TITLE
Ractive.js updates - Fix deprecation warning, added parsed caching, improved data object

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -737,7 +737,9 @@ exports.ractive = fromStringRenderer('ractive');
 exports.ractive.render = function(str, options, fn){
   var engine = requires.ractive || (requires.ractive = require('ractive'));
 
-  options.template = str;
+  var template = cache(options) || cache(options, engine.parse(str));
+  options.template = template;
+  
   if (options.data === null || options.data === undefined)
   {
     options.data = options;

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -744,7 +744,7 @@ exports.ractive.render = function(str, options, fn){
   }
 
   try {
-    fn(null, new engine(options).renderHTML());
+    fn(null, new engine(options).toHTML());
   } catch (err) {
     fn(err);
   }

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -742,7 +742,18 @@ exports.ractive.render = function(str, options, fn){
   
   if (options.data === null || options.data === undefined)
   {
-    options.data = options;
+    var extend = (requires.extend || (requires.extend = require('util')._extend));
+    
+    // Shallow clone the options object
+    options.data = extend({}, options);
+    
+    // Remove consolidate-specific properties from the clone
+    var i, length;
+    var properties = ["template", "filename", "cache", "partials"];
+    for (i = 0, length = properties.length; i < length; i++) {
+      var property = properties[i];
+      delete options.data[property];
+    }
   }
 
   try {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "atpl": ">=0.7.6",
     "templayed": ">=0.2.3",
     "dot": "1.0.1",
-    "ractive": "0.3.7",
+    "ractive": "~0.4.0",
     "nunjucks": "~1.0.0"
   },
   "main": "index",


### PR DESCRIPTION
atpl is throwing an error on test - All Ractive tests passing.