### PR TITLE
fixing tests for atpl updates

### DIFF
--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -44,7 +44,7 @@ exports.test = function(name) {
         cons[name](path, locals, function(err, html){
           if (err) return done(err);
           html.should.equal('<p>Tobi</p>');
-          calls.should.equal(2);
+          calls.should.equal(name === 'atpl' ? 4 : 2);
           done();
         });
       });


### PR DESCRIPTION
atpl added additional `fs.readFile` and `fs.readFileSync` calls when not caching.

Updating tests to account for the atpl changing.