### PR TITLE
expose 'requires' object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -126,6 +126,23 @@ app.listen(3000);
 console.log('Express server listening on port 3000');
 ```
 
+## Template Engine Instances
+
+Template engines are exposed via the `cons.requires` object, but they are not instantiated until you've called the `cons[engine].render()` method. You can instantiate them manually beforehand if you want to add filters, globals, mixins, or other engine features.
+
+```js
+var cons = require('consolidate'),
+  nunjucks = require('nunjucks');
+
+// add nunjucks to requires so filters can be
+// added and the same instance will be used inside the render method
+cons.requires.nunjucks = nunjucks;
+
+cons.requires.nunjucks.addFilter('foo', function () {
+  return 'bar';
+});
+```
+
 ## Notes
 
 * You can pass **partials** with `options.partials`

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -956,3 +956,9 @@ exports.htmling.render = function(str, options, fn) {
     fn(err);
   }
 };
+
+/**
+ * expose the instance of the engine
+ */
+
+exports.requires = requires;

--- a/test/consolidate.js
+++ b/test/consolidate.js
@@ -36,4 +36,5 @@ require('./shared').test('dot');
 require('./shared').test('ractive');
 require('./shared/partials').test('ractive');
 require('./shared').test('nunjucks');
+require('./shared/filters').test('nunjucks');
 require('./shared').test('htmling');

--- a/test/fixtures/nunjucks/filters.nunjucks
+++ b/test/fixtures/nunjucks/filters.nunjucks
@@ -1,0 +1,1 @@
+{{user.name | upper}}

--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -79,5 +79,19 @@ exports.test = function(name) {
         done();
       });
     });
+
+    it('should be exposed in the requires object', function(){
+      var should = require('should'),
+        requiredName;
+      // haml and haml-coffee are exposed under different names
+      if (name === 'haml') {
+        requiredName = 'hamljs';
+      } else if (name === 'haml-coffee') {
+        requiredName = 'HAMLCoffee';
+      } else {
+        requiredName = name;
+      }
+      should.exist(cons.requires[requiredName]);
+    });
   });
 };


### PR DESCRIPTION
* exposes `requires`, and thus engine instances
* added basic tests for those
* added nunjucks filters test

This allows developers to access the engine instance itself, e.g.

```js
var cons = require('consolidate'),
  nunjucks = require('nunjucks');

cons.requires.nunjucks.addFilter('foo', function () {
  return 'bar';
});
```