### PR TITLE
docs update for requires

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -137,7 +137,7 @@ var cons = require('consolidate'),
 
 // add nunjucks to requires so filters can be
 // added and the same instance will be used inside the render method
-cons.requires.nunjucks = nunjucks;
+cons.requires.nunjucks = nunjucks.configure();
 
 cons.requires.nunjucks.addFilter('foo', function () {
   return 'bar';


### PR DESCRIPTION
The current example should show `nunjucks.configure()`, since that's how to create a new nunjucks env.