### PR TITLE
Add support for Promises

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -156,14 +156,7 @@ function fromStringRenderer(name) {
   return function(path, options, fn){
     options.filename = path;
 
-    return q.Promise(function (res, rej) {
-      fn = fn || function completePromise(err, html) {
-        if (err) {
-          return rej(err);
-        }
-        res(html);
-      };
-
+    return promisify(fn, function(fn) {
       readPartials(path, options, function (err) {
         if (err) return fn(err);
         if (cache(options)) {

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -300,25 +300,27 @@ exports.liquid.render = function(str, options, fn){
  */
 
 exports.jade = function(path, options, fn){
-  var engine = requires.jade;
-  if (!engine) {
-    try {
-      engine = requires.jade = require('jade');
-    } catch (err) {
+  return promisify(fn, function (fn) {
+    var engine = requires.jade;
+    if (!engine) {
       try {
-        engine = requires.jade = require('then-jade');
-      } catch (otherError) {
-        throw err;
+        engine = requires.jade = require('jade');
+      } catch (err) {
+        try {
+          engine = requires.jade = require('then-jade');
+        } catch (otherError) {
+          throw err;
+        }
       }
     }
-  }
 
-  try {
-    var tmpl = cache(options) || cache(options, engine.compileFile(path, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+    try {
+      var tmpl = cache(options) || cache(options, engine.compileFile(path, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -607,8 +609,10 @@ exports.hamlet.render = function(str, options, fn){
  */
 
 exports.whiskers = function(path, options, fn){
-  var engine = requires.whiskers || (requires.whiskers = require('whiskers'));
-  engine.__express(path, options, fn);
+  return promisify(fn, function (fn) {
+    var engine = requires.whiskers || (requires.whiskers = require('whiskers'));
+    engine.__express(path, options, fn);
+  });
 };
 
 /**
@@ -868,13 +872,15 @@ exports.just.render = function(str, options, fn){
  */
 
 exports.ect = function(path, options, fn){
-  var engine = requires.ect;
-  if (!engine) {
-    var ECT = require('ect');
-    engine = requires.ect = new ECT(options);
-  }
-  engine.configure({ cache: options.cache });
-  engine.render(path, options, fn);
+  return promisify(fn, function (fn) {
+    var engine = requires.ect;
+    if (!engine) {
+      var ECT = require('ect');
+      engine = requires.ect = new ECT(options);
+    }
+    engine.configure({ cache: options.cache });
+    engine.render(path, options, fn);
+  });
 };
 
 /**

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1130,58 +1130,59 @@ function reactRenderer(type){
 
   // Return rendering fx
   return function(str, options, fn) {
+    return promisify(fn, function(fn) {
+      // React Import
+      var engine = requires.react || (requires.react = require('react'));
 
-    // React Import
-    var engine = requires.react || (requires.react = require('react'));
+      // Assign HTML Base
+      var base = options.base;
+      delete options.base;
 
-    // Assign HTML Base
-    var base = options.base;
-    delete options.base;
+      var enableCache = options.cache;
+      delete options.cache;
 
-    var enableCache = options.cache;
-    delete options.cache;
+      var isNonStatic = options.isNonStatic;
+      delete options.isNonStatic;
 
-    var isNonStatic = options.isNonStatic;
-    delete options.isNonStatic;
+      // Start Conversion
+      try {
 
-    // Start Conversion
-    try {
+        var Code,
+            Factory;
 
-      var Code,
-          Factory;
+        var baseStr,
+            content,
+            parsed;
 
-      var baseStr,
-          content,
-          parsed;
+        if (!cache(options)){
+          // Parsing
+          Code = (type === 'path') ? require(resolve(str)) : requireReactString(str);
+          Factory = cache(options, engine.createFactory(Code));
 
-      if (!cache(options)){
-        // Parsing
-        Code = (type === 'path') ? require(resolve(str)) : requireReactString(str);
-        Factory = cache(options, engine.createFactory(Code));
-
-      } else {
-        Factory = cache(options);
-      }
-
-      parsed = new Factory(options);
-      content = (isNonStatic) ? engine.renderToString(parsed) : engine.renderToStaticMarkup(parsed);
-
-      if (base){
-        baseStr = readCache[str] || fs.readFileSync(resolve(base), 'utf8');
-
-        if (enableCache){
-          readCache[str] = baseStr;
+        } else {
+          Factory = cache(options);
         }
 
-        options.content = content;
-        content = reactBaseTmpl(baseStr, options);
+        parsed = new Factory(options);
+        content = (isNonStatic) ? engine.renderToString(parsed) : engine.renderToStaticMarkup(parsed);
+
+        if (base){
+          baseStr = readCache[str] || fs.readFileSync(resolve(base), 'utf8');
+
+          if (enableCache){
+            readCache[str] = baseStr;
+          }
+
+          options.content = content;
+          content = reactBaseTmpl(baseStr, options);
+        }
+
+        fn(null, content);
+
+      } catch (err) {
+        fn(err);
       }
-
-      fn(null, content);
-
-    } catch (err) {
-      fn(err);
-    }
+    });
   };
 }
 

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -22,7 +22,7 @@ var fs = require('fs')
   , join = path.join
   , resolve = path.resolve
   , extname = path.extname
-  , q = require('q')
+  , Promise = require('bluebird')
   , dirname = path.dirname;
 
 var readCache = {};
@@ -136,7 +136,7 @@ function readPartials(path, options, fn) {
  * promisify
  */
 function promisify(fn, exec) {
-  return q.Promise(function (res, rej) {
+  return new Promise(function (res, rej) {
     fn = fn || function (err, html) {
       if (err) {
         return rej(err);

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -964,7 +964,7 @@ exports.htmling.render = function(str, options, fn) {
  */
 function requireReact(module, filename) {
   var tools = requires.reactTools || (requires.reactTools = require('react-tools'));
-  
+
   var content = fs.readFileSync(filename, 'utf8');
   var compiled = tools.transform(content, {harmony: true});
 
@@ -1060,7 +1060,7 @@ function reactRenderer(type){
         // Parsing
         Code = (type === 'path') ? require(resolve(str)) : requireReactString(str);
         Factory = cache(options, engine.createFactory(Code));
-      
+
       } else {
         Factory = cache(options);
       }

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -22,6 +22,7 @@ var fs = require('fs')
   , join = path.join
   , resolve = path.resolve
   , extname = path.extname
+  , q = require('q')
   , dirname = path.dirname;
 
 var readCache = {};
@@ -130,6 +131,23 @@ function readPartials(path, options, fn) {
   next(0);
 }
 
+
+/**
+ * promisify
+ */
+function promisify(fn, exec) {
+  return q.Promise(function (res, rej) {
+    fn = fn || function (err, html) {
+      if (err) {
+        return rej(err);
+      }
+      res(html);
+    };
+    exec(fn);
+  });
+}
+
+
 /**
  * fromStringRenderer
  */
@@ -137,16 +155,26 @@ function readPartials(path, options, fn) {
 function fromStringRenderer(name) {
   return function(path, options, fn){
     options.filename = path;
-    readPartials(path, options, function (err) {
-      if (err) return fn(err);
-      if (cache(options)) {
-        exports[name].render('', options, fn);
-      } else {
-        read(path, options, function(err, str){
-          if (err) return fn(err);
-          exports[name].render(str, options, fn);
-        });
-      }
+
+    return q.Promise(function (res, rej) {
+      fn = fn || function completePromise(err, html) {
+        if (err) {
+          return rej(err);
+        }
+        res(html);
+      };
+
+      readPartials(path, options, function (err) {
+        if (err) return fn(err);
+        if (cache(options)) {
+          exports[name].render('', options, fn);
+        } else {
+          read(path, options, function(err, str){
+            if (err) return fn(err);
+            exports[name].render(str, options, fn);
+          });
+        }
+      });
     });
   };
 }
@@ -170,99 +198,101 @@ exports.liquid = fromStringRenderer('liquid');
  */
 
 exports.liquid.render = function(str, options, fn){
-  var engine = requires.liquid || (requires.liquid = require('tinyliquid'));
-  try {
-    var context = engine.newContext();
-    var k;
+  return promisify(fn, function (fn) {
+    var engine = requires.liquid || (requires.liquid = require('tinyliquid'));
+    try {
+      var context = engine.newContext();
+      var k;
 
-    /**
-     * Note that there's a bug in the library that doesn't allow us to pass
-     * the locals to newContext(), hence looping through the keys:
-     */
+      /**
+       * Note that there's a bug in the library that doesn't allow us to pass
+       * the locals to newContext(), hence looping through the keys:
+       */
 
-    if (options.locals){
-      for (k in options.locals){
-        context.setLocals(k, options.locals[k]);
+      if (options.locals){
+        for (k in options.locals){
+          context.setLocals(k, options.locals[k]);
+        }
+        delete options.locals;
       }
-      delete options.locals;
-    }
 
-    if (options.meta){
-      context.setLocals('page', options.meta);
-      delete options.meta;
-    }
-
-    /**
-     * Add any defined filters:
-     */
-
-    if (options.filters){
-      for (k in options.filters){
-        context.setFilter(k, options.filters[k]);
+      if (options.meta){
+        context.setLocals('page', options.meta);
+        delete options.meta;
       }
-      delete options.filters;
-    }
 
-    /**
-     * Set up a callback for the include directory:
-     */
+      /**
+       * Add any defined filters:
+       */
 
-    var includeDir = options.includeDir || process.cwd();
+      if (options.filters){
+        for (k in options.filters){
+          context.setFilter(k, options.filters[k]);
+        }
+        delete options.filters;
+      }
 
-    context.onInclude(function (name, callback) {
-      var basename = path.basename(name);
-      var extname = path.extname(name) || '.liquid';
-      var filename = path.join(includeDir, basename + extname);
+      /**
+       * Set up a callback for the include directory:
+       */
 
-      fs.readFile(filename, {encoding: 'utf8'}, function (err, data){
-        if (err) return callback(err);
-        callback(null, engine.parse(data));
+      var includeDir = options.includeDir || process.cwd();
+
+      context.onInclude(function (name, callback) {
+        var basename = path.basename(name);
+        var extname = path.extname(name) || '.liquid';
+        var filename = path.join(includeDir, basename + extname);
+
+        fs.readFile(filename, {encoding: 'utf8'}, function (err, data){
+          if (err) return callback(err);
+          callback(null, engine.parse(data));
+        });
       });
-    });
-    delete options.includeDir;
+      delete options.includeDir;
 
-    /**
-     * The custom tag functions need to have their results pushed back
-     * through the parser, so set up a shim before calling the provided
-     * callback:
-     */
+      /**
+       * The custom tag functions need to have their results pushed back
+       * through the parser, so set up a shim before calling the provided
+       * callback:
+       */
 
-    var compileOptions = {
-      customTags: {}
-    };
+      var compileOptions = {
+        customTags: {}
+      };
 
-    if (options.customTags){
-      var tagFunctions = options.customTags;
+      if (options.customTags){
+        var tagFunctions = options.customTags;
 
-      for (k in options.customTags){
-        /*Tell jshint there's no problem with having this function in the loop */
-        /*jshint -W083 */
-        compileOptions.customTags[k] = function (context, name, body){
-          var tpl = tagFunctions[name](body.trim());
-          context.astStack.push(engine.parse(tpl));
-        };
-        /*jshint +W083 */
+        for (k in options.customTags){
+          /*Tell jshint there's no problem with having this function in the loop */
+          /*jshint -W083 */
+          compileOptions.customTags[k] = function (context, name, body){
+            var tpl = tagFunctions[name](body.trim());
+            context.astStack.push(engine.parse(tpl));
+          };
+          /*jshint +W083 */
+        }
+        delete options.customTags;
       }
-      delete options.customTags;
+
+      /**
+       * Now anything left in `options` becomes a local:
+       */
+
+      for (k in options){
+        context.setLocals(k, options[k]);
+      }
+
+      /**
+       * Finally, execute the template:
+       */
+
+      var tmpl = cache(context) || cache(context, engine.compile(str, compileOptions));
+      tmpl(context, fn);
+    } catch (err) {
+      fn(err);
     }
-
-    /**
-     * Now anything left in `options` becomes a local:
-     */
-
-    for (k in options){
-      context.setLocals(k, options[k]);
-    }
-
-    /**
-     * Finally, execute the template:
-     */
-
-    var tmpl = cache(context) || cache(context, engine.compile(str, compileOptions));
-    tmpl(context, fn);
-  } catch (err) {
-    fn(err);
-  }
+  });
 };
 
 /**
@@ -296,25 +326,27 @@ exports.jade = function(path, options, fn){
  */
 
 exports.jade.render = function(str, options, fn){
-  var engine = requires.jade;
-  if (!engine) {
-    try {
-      engine = requires.jade = require('jade');
-    } catch (err) {
+  return promisify(fn, function (fn) {
+    var engine = requires.jade;
+    if (!engine) {
       try {
-        engine = requires.jade = require('then-jade');
-      } catch (otherError) {
-        throw err;
+        engine = requires.jade = require('jade');
+      } catch (err) {
+        try {
+          engine = requires.jade = require('then-jade');
+        } catch (otherError) {
+          throw err;
+        }
       }
     }
-  }
 
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -328,41 +360,43 @@ exports.dust = fromStringRenderer('dust');
  */
 
 exports.dust.render = function(str, options, fn){
-  var engine = requires.dust;
-  if (!engine) {
-    try {
-      engine = requires.dust = require('dust');
-    } catch (err) {
+  return promisify(fn, function(fn) {
+    var engine = requires.dust;
+    if (!engine) {
       try {
-        engine = requires.dust = require('dustjs-helpers');
+        engine = requires.dust = require('dust');
       } catch (err) {
-        engine = requires.dust = require('dustjs-linkedin');
+        try {
+          engine = requires.dust = require('dustjs-helpers');
+        } catch (err) {
+          engine = requires.dust = require('dustjs-linkedin');
+        }
       }
     }
-  }
 
-  var ext = 'dust'
-    , views = '.';
+    var ext = 'dust'
+      , views = '.';
 
-  if (options) {
-    if (options.ext) ext = options.ext;
-    if (options.views) views = options.views;
-    if (options.settings && options.settings.views) views = options.settings.views;
-  }
-  if (!options || (options && !options.cache)) engine.cache = {};
+    if (options) {
+      if (options.ext) ext = options.ext;
+      if (options.views) views = options.views;
+      if (options.settings && options.settings.views) views = options.settings.views;
+    }
+    if (!options || (options && !options.cache)) engine.cache = {};
 
-  engine.onLoad = function(path, callback){
-    if ('' == extname(path)) path += '.' + ext;
-    if ('/' !== path[0]) path = views + '/' + path;
-    read(path, options, callback);
-  };
+    engine.onLoad = function(path, callback){
+      if ('' == extname(path)) path += '.' + ext;
+      if ('/' !== path[0]) path = views + '/' + path;
+      read(path, options, callback);
+    };
 
-  try {
-    var tmpl = cache(options) || cache(options, engine.compileFn(str));
-    tmpl(options, fn);
-  } catch (err) {
-    fn(err);
-  }
+    try {
+      var tmpl = cache(options) || cache(options, engine.compileFn(str));
+      tmpl(options, fn);
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -376,16 +410,18 @@ exports.swig = fromStringRenderer('swig');
  */
 
 exports.swig.render = function(str, options, fn){
-  var engine = requires.swig || (requires.swig = require('swig'));
+  return promisify(fn, function(fn) {
+    var engine = requires.swig || (requires.swig = require('swig'));
 
-  try {
-    if(options.cache === true) options.cache = 'memory';
-    engine.setDefaults({ cache: options.cache });
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+    try {
+      if(options.cache === true) options.cache = 'memory';
+      engine.setDefaults({ cache: options.cache });
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -399,13 +435,15 @@ exports.atpl = fromStringRenderer('atpl');
  */
 
 exports.atpl.render = function(str, options, fn){
-  var engine = requires.atpl || (requires.atpl = require('atpl'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.atpl || (requires.atpl = require('atpl'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -419,13 +457,15 @@ exports.liquor = fromStringRenderer('liquor');
  */
 
 exports.liquor.render = function(str, options, fn){
-  var engine = requires.liquor || (requires.liquor = require('liquor'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.liquor || (requires.liquor = require('liquor'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -439,13 +479,15 @@ exports.ejs = fromStringRenderer('ejs');
  */
 
 exports.ejs.render = function(str, options, fn){
-  var engine = requires.ejs || (requires.ejs = require('ejs'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.ejs || (requires.ejs = require('ejs'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 
@@ -460,12 +502,14 @@ exports.eco = fromStringRenderer('eco');
  */
 
 exports.eco.render = function(str, options, fn){
-  var engine = requires.eco || (requires.eco = require('eco'));
-  try {
-    fn(null, engine.render(str, options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.eco || (requires.eco = require('eco'));
+    try {
+      fn(null, engine.render(str, options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -479,15 +523,17 @@ exports.jazz = fromStringRenderer('jazz');
  */
 
 exports.jazz.render = function(str, options, fn){
-  var engine = requires.jazz || (requires.jazz = require('jazz'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    tmpl.eval(options, function(str){
-      fn(null, str);
-    });
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.jazz || (requires.jazz = require('jazz'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      tmpl.eval(options, function(str){
+        fn(null, str);
+      });
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -501,13 +547,15 @@ exports.jqtpl = fromStringRenderer('jqtpl');
  */
 
 exports.jqtpl.render = function(str, options, fn){
-  var engine = requires.jqtpl || (requires.jqtpl = require('jqtpl'));
-  try {
-    engine.template(str, str);
-    fn(null, engine.tmpl(str, options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.jqtpl || (requires.jqtpl = require('jqtpl'));
+    try {
+      engine.template(str, str);
+      fn(null, engine.tmpl(str, options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -521,13 +569,15 @@ exports.haml = fromStringRenderer('haml');
  */
 
 exports.haml.render = function(str, options, fn){
-  var engine = requires.hamljs || (requires.hamljs = require('hamljs'));
-  try {
-    options.locals = options;
-    fn(null, engine.render(str, options).trimLeft());
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.hamljs || (requires.hamljs = require('hamljs'));
+    try {
+      options.locals = options;
+      fn(null, engine.render(str, options).trimLeft());
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -541,13 +591,15 @@ exports.hamlet = fromStringRenderer('hamlet');
  */
 
 exports.hamlet.render = function(str, options, fn){
-  var engine = requires.hamlet || (requires.hamlet = require('hamlet'));
-  try {
-    options.locals = options;
-    fn(null, engine.render(str, options).trimLeft());
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.hamlet || (requires.hamlet = require('hamlet'));
+    try {
+      options.locals = options;
+      fn(null, engine.render(str, options).trimLeft());
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -564,12 +616,14 @@ exports.whiskers = function(path, options, fn){
  */
 
 exports.whiskers.render = function(str, options, fn){
-  var engine = requires.whiskers || (requires.whiskers = require('whiskers'));
-  try {
-    fn(null, engine.render(str, options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.whiskers || (requires.whiskers = require('whiskers'));
+    try {
+      fn(null, engine.render(str, options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -583,13 +637,15 @@ exports['haml-coffee'] = fromStringRenderer('haml-coffee');
  */
 
 exports['haml-coffee'].render = function(str, options, fn){
-  var engine = requires.HAMLCoffee || (requires.HAMLCoffee = require('haml-coffee'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.HAMLCoffee || (requires.HAMLCoffee = require('haml-coffee'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -603,13 +659,15 @@ exports.hogan = fromStringRenderer('hogan');
  */
 
 exports.hogan.render = function(str, options, fn){
-  var engine = requires.hogan || (requires.hogan = require('hogan.js'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl.render(options, options.partials));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.hogan || (requires.hogan = require('hogan.js'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl.render(options, options.partials));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -623,13 +681,15 @@ exports.templayed = fromStringRenderer('templayed');
  */
 
 exports.templayed.render = function(str, options, fn){
-  var engine = requires.templayed || (requires.templayed = require('templayed'));
-  try {
-    var tmpl = cache(options) || cache(options, engine(str));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.templayed || (requires.templayed = require('templayed'));
+    try {
+      var tmpl = cache(options) || cache(options, engine(str));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -643,19 +703,21 @@ exports.handlebars = fromStringRenderer('handlebars');
  */
 
 exports.handlebars.render = function(str, options, fn) {
-  var engine = requires.handlebars || (requires.handlebars = require('handlebars'));
-  try {
-    for (var partial in options.partials) {
-      engine.registerPartial(partial, options.partials[partial]);
+  return promisify(fn, function(fn) {
+    var engine = requires.handlebars || (requires.handlebars = require('handlebars'));
+    try {
+      for (var partial in options.partials) {
+        engine.registerPartial(partial, options.partials[partial]);
+      }
+      for (var helper in options.helpers) {
+        engine.registerHelper(helper, options.helpers[helper]);
+      }
+      var tmpl = cache(options) || cache(options, engine.compile(str, options));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
     }
-    for (var helper in options.helpers) {
-      engine.registerHelper(helper, options.helpers[helper]);
-    }
-    var tmpl = cache(options) || cache(options, engine.compile(str, options));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  });
 }
 
 /**
@@ -669,13 +731,15 @@ exports.underscore = fromStringRenderer('underscore');
  */
 
 exports.underscore.render = function(str, options, fn) {
-  var engine = requires.underscore || (requires.underscore = require('underscore'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.template(str, null, options));
-    fn(null, tmpl(options).replace(/\n$/, ''));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function(fn) {
+    var engine = requires.underscore || (requires.underscore = require('underscore'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.template(str, null, options));
+      fn(null, tmpl(options).replace(/\n$/, ''));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 
@@ -690,13 +754,15 @@ exports.lodash = fromStringRenderer('lodash');
  */
 
 exports.lodash.render = function(str, options, fn) {
-  var engine = requires.lodash || (requires.lodash = require('lodash'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.template(str, null, options));
-    fn(null, tmpl(options).replace(/\n$/, ''));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.lodash || (requires.lodash = require('lodash'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.template(str, null, options));
+      fn(null, tmpl(options).replace(/\n$/, ''));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 
@@ -711,16 +777,18 @@ exports.qejs = fromStringRenderer('qejs');
  */
 
 exports.qejs.render = function (str, options, fn) {
-  try {
-    var engine = requires.qejs || (requires.qejs = require('qejs'));
-    engine.render(str, options).then(function (result) {
-        fn(null, result);
-    }, function (err) {
-        fn(err);
-    }).done();
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    try {
+      var engine = requires.qejs || (requires.qejs = require('qejs'));
+      engine.render(str, options).then(function (result) {
+          fn(null, result);
+      }, function (err) {
+          fn(err);
+      }).done();
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 
@@ -735,13 +803,15 @@ exports.walrus = fromStringRenderer('walrus');
  */
 
 exports.walrus.render = function (str, options, fn) {
-  var engine = requires.walrus || (requires.walrus = require('walrus'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.parse(str));
-    fn(null, tmpl.compile(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.walrus || (requires.walrus = require('walrus'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.parse(str));
+      fn(null, tmpl.compile(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -755,12 +825,14 @@ exports.mustache = fromStringRenderer('mustache');
  */
 
 exports.mustache.render = function(str, options, fn) {
-  var engine = requires.mustache || (requires.mustache = require('mustache'));
-  try {
-    fn(null, engine.to_html(str, options, options.partials));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.mustache || (requires.mustache = require('mustache'));
+    try {
+      fn(null, engine.to_html(str, options, options.partials));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -768,13 +840,15 @@ exports.mustache.render = function(str, options, fn) {
  */
 
 exports.just = function(path, options, fn){
-  var engine = requires.just;
-  if (!engine) {
-    var JUST = require('just');
-    engine = requires.just = new JUST();
-  }
-  engine.configure({ useCache: options.cache });
-  engine.render(path, options, fn);
+  return promisify(fn, function(fn) {
+    var engine = requires.just;
+    if (!engine) {
+      var JUST = require('just');
+      engine = requires.just = new JUST();
+    }
+    engine.configure({ useCache: options.cache });
+    engine.render(path, options, fn);
+  });
 };
 
 /**
@@ -782,9 +856,11 @@ exports.just = function(path, options, fn){
  */
 
 exports.just.render = function(str, options, fn){
-  var JUST = require('just');
-  var engine = new JUST({ root: { page: str }});
-  engine.render('page', options, fn);
+  return promisify(fn, function (fn) {
+    var JUST = require('just');
+    var engine = new JUST({ root: { page: str }});
+    engine.render('page', options, fn);
+  });
 };
 
 /**
@@ -806,9 +882,11 @@ exports.ect = function(path, options, fn){
  */
 
 exports.ect.render = function(str, options, fn){
-  var ECT = require('ect');
-  var engine = new ECT({ root: { page: str }});
-  engine.render('page', options, fn);
+  return promisify(fn, function (fn) {
+    var ECT = require('ect');
+    var engine = new ECT({ root: { page: str }});
+    engine.render('page', options, fn);
+  });
 };
 
 /**
@@ -822,13 +900,15 @@ exports.mote = fromStringRenderer('mote');
  */
 
 exports.mote.render = function(str, options, fn){
-  var engine = requires.mote || (requires.mote = require('mote'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.mote || (requires.mote = require('mote'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -836,8 +916,10 @@ exports.mote.render = function(str, options, fn){
  */
 
 exports.toffee = function(path, options, fn){
-  var toffee = requires.toffee || (requires.toffee = require('toffee'));
-  toffee.__consolidate_engine_render(path, options, fn);
+  return promisify(fn, function (fn) {
+    var toffee = requires.toffee || (requires.toffee = require('toffee'));
+    toffee.__consolidate_engine_render(path, options, fn);
+  });
 };
 
 /**
@@ -845,12 +927,14 @@ exports.toffee = function(path, options, fn){
  */
 
 exports.toffee.render = function(str, options, fn) {
-  var engine = requires.toffee || (requires.toffee = require('toffee'));
-  try {
-  	engine.str_render(str, options,fn);
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.toffee || (requires.toffee = require('toffee'));
+    try {
+      engine.str_render(str, options,fn);
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -864,13 +948,15 @@ exports.dot = fromStringRenderer('dot');
  */
 
 exports.dot.render = function (str, options, fn) {
-  var engine = requires.dot || (requires.dot = require('dot'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.compile(str, options && options._def));
-    fn(null, tmpl(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.dot || (requires.dot = require('dot'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.compile(str, options && options._def));
+      fn(null, tmpl(options));
+    } catch (err) {
+      fn(err);
+      }
+  });
 };
 
 /**
@@ -884,32 +970,34 @@ exports.ractive = fromStringRenderer('ractive');
  */
 
 exports.ractive.render = function(str, options, fn){
-  var engine = requires.ractive || (requires.ractive = require('ractive'));
+  return promisify(fn, function (fn) {
+    var engine = requires.ractive || (requires.ractive = require('ractive'));
 
-  var template = cache(options) || cache(options, engine.parse(str));
-  options.template = template;
+    var template = cache(options) || cache(options, engine.parse(str));
+    options.template = template;
 
-  if (options.data === null || options.data === undefined)
-  {
-    var extend = (requires.extend || (requires.extend = require('util')._extend));
+    if (options.data === null || options.data === undefined)
+    {
+      var extend = (requires.extend || (requires.extend = require('util')._extend));
 
-    // Shallow clone the options object
-    options.data = extend({}, options);
+      // Shallow clone the options object
+      options.data = extend({}, options);
 
-    // Remove consolidate-specific properties from the clone
-    var i, length;
-    var properties = ["template", "filename", "cache", "partials"];
-    for (i = 0, length = properties.length; i < length; i++) {
-     var property = properties[i];
-     delete options.data[property];
+      // Remove consolidate-specific properties from the clone
+      var i, length;
+      var properties = ["template", "filename", "cache", "partials"];
+      for (i = 0, length = properties.length; i < length; i++) {
+       var property = properties[i];
+       delete options.data[property];
+      }
     }
-  }
 
-  try {
-    fn(null, new engine(options).toHTML());
-  } catch (err) {
-    fn(err);
-  }
+    try {
+      fn(null, new engine(options).toHTML());
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 /**
@@ -923,18 +1011,20 @@ exports.nunjucks = fromStringRenderer('nunjucks');
  */
 
 exports.nunjucks.render = function(str, options, fn) {
-  try {
-    var engine = requires.nunjucks || (requires.nunjucks = require('nunjucks'));
-    var loader = options.loader;
-    if (loader) {
+  return promisify(fn, function (fn) {
+    try {
+      var engine = requires.nunjucks || (requires.nunjucks = require('nunjucks'));
+      var loader = options.loader;
+      if (loader) {
         var env = new engine.Environment(new loader(options));
         env.renderString(str, options, fn);
-    } else {
+      } else {
         engine.renderString(str, options, fn);
-    }
-  } catch (err) {
+      }
+    } catch (err) {
       throw fn(err);
-  }
+    }
+  });
 };
 
 
@@ -949,13 +1039,15 @@ exports.htmling = fromStringRenderer('htmling');
  */
 
 exports.htmling.render = function(str, options, fn) {
-  var engine = requires.htmling || (requires.htmling = require('htmling'));
-  try {
-    var tmpl = cache(options) || cache(options, engine.string(str));
-    fn(null, tmpl.render(options));
-  } catch (err) {
-    fn(err);
-  }
+  return promisify(fn, function (fn) {
+    var engine = requires.htmling || (requires.htmling = require('htmling'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.string(str));
+      fn(null, tmpl.render(options));
+    } catch (err) {
+      fn(err);
+    }
+  });
 };
 
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   },
   "scripts": {
     "test": "mocha"
+  },
+  "dependencies": {
+    "q": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "test": "mocha"
   },
   "dependencies": {
-    "q": "^1.4.1"
+    "bluebird": "^2.9.26"
   }
 }

--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -80,6 +80,20 @@ exports.test = function(name) {
       });
     });
 
+    it('should return a promise', function(done){
+      var str = fs.readFileSync('test/fixtures/' + name + '/user.' + name).toString();
+      var locals = { user: user };
+      var result = cons[name].render(str, locals);
+
+      result.then(function (html) {
+        html.should.equal('<p>Tobi</p>');
+        done();
+      })
+      .catch(function (err) {
+        done(err);
+      });
+    });
+
     it('should be exposed in the requires object', function(){
       var should = require('should'),
         requiredName;

--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -80,7 +80,21 @@ exports.test = function(name) {
       });
     });
 
-    it('should return a promise', function(done){
+    it('should return a promise if no callback provided', function(done){
+      var path = 'test/fixtures/' + name + '/user.' + name;
+      var locals = { user: user };
+      var result = cons[name](path, locals);
+
+      result.then(function (html) {
+        html.should.equal('<p>Tobi</p>');
+        done();
+      })
+      .catch(function (err) {
+        done(err);
+      });
+    });
+
+    it('should return a promise if no callback provided (string)', function(done){
       var str = fs.readFileSync('test/fixtures/' + name + '/user.' + name).toString();
       var locals = { user: user };
       var result = cons[name].render(str, locals);

--- a/test/shared/react.js
+++ b/test/shared/react.js
@@ -35,6 +35,18 @@ exports.test = function(name) {
       });
     });
 
+    it('should support promises', function(done){
+      var path = 'test/fixtures/' + name + '/user.' + name;
+      var locals = { user: user };
+      cons[name](path, locals)
+        .then(function(html){
+          html.should.equal('<p>Tobi</p>');
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
 
     it('should support rendering a string', function(done){
       var str = fs.readFileSync('test/fixtures/' + name + '/user.' + name).toString();
@@ -49,6 +61,21 @@ exports.test = function(name) {
         html.should.equal('<p>Tobi</p>');
         done();
       });
+    });
+
+
+    it('should support promises from a string', function(done){
+      var str = fs.readFileSync('test/fixtures/' + name + '/user.' + name).toString();
+      var locals = { user: user };
+
+      cons[name].render(str, locals)
+        .then(function(html){
+          html.should.equal('<p>Tobi</p>');
+          done();
+        })
+        .catch(function (err) {
+          return done(err);
+        });
     });
 
 


### PR DESCRIPTION
If no callback `fn` is provided, render functions should return Promises which either resolve to the compiled HTML or an error.

No changes are made to the regular API, only the addition of the return value when no callback is provided.