### PR TITLE
Normalize keys in "requires" object

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -565,7 +565,7 @@ exports.haml = fromStringRenderer('haml');
 
 exports.haml.render = function(str, options, fn){
   return promisify(fn, function(fn) {
-    var engine = requires.hamljs || (requires.hamljs = require('hamljs'));
+    var engine = requires.haml || (requires.haml = require('hamljs'));
     try {
       options.locals = options;
       fn(null, engine.render(str, options).trimLeft());
@@ -635,7 +635,7 @@ exports['haml-coffee'] = fromStringRenderer('haml-coffee');
 
 exports['haml-coffee'].render = function(str, options, fn){
   return promisify(fn, function(fn) {
-    var engine = requires.HAMLCoffee || (requires.HAMLCoffee = require('haml-coffee'));
+    var engine = requires['haml-coffee'] || (requires['haml-coffee'] = require('haml-coffee'));
     try {
       var tmpl = cache(options) || cache(options, engine.compile(str, options));
       fn(null, tmpl(options));

--- a/test/shared/index.js
+++ b/test/shared/index.js
@@ -110,15 +110,7 @@ exports.test = function(name) {
 
     it('should be exposed in the requires object', function(){
       var should = require('should'),
-        requiredName;
-      // haml and haml-coffee are exposed under different names
-      if (name === 'haml') {
-        requiredName = 'hamljs';
-      } else if (name === 'haml-coffee') {
-        requiredName = 'HAMLCoffee';
-      } else {
         requiredName = name;
-      }
       should.exist(cons.requires[requiredName]);
     });
   });


### PR DESCRIPTION
It's clear from the existing tests that the different keys were intentional, but there are a couple of good reasons to normalize them:

1. It makes it a lot easier to automate the process of pre-loading an engine into the requires object (you don't have to keep track of the alternate key names)
2. The current scheme is not consistent--Liquid loads the "tinyliquid" engine but uses "requires.liquid", and Hogan loads the "hogan.js" engine but uses "requires.hogan"