### PR TITLE
using fs-read-queue to prevent ENFILE errors

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -18,6 +18,7 @@
  */
 
 var fs = require('fs')
+  , readFile = require('fs-read-queue')
   , path = require('path')
   , join = path.join
   , resolve = path.resolve
@@ -93,7 +94,7 @@ function read(path, options, fn) {
   if (cached) return fn(null, str);
 
   // read
-  fs.readFile(path, 'utf8', function(err, str){
+  readFile(path, 'utf8', function(err, str){
     if (err) return fn(err);
     // remove extraneous utf8 BOM marker
     str = str.replace(/^\uFEFF/, '');
@@ -236,7 +237,7 @@ exports.liquid.render = function(str, options, fn){
         var extname = path.extname(name) || '.liquid';
         var filename = path.join(includeDir, basename + extname);
 
-        fs.readFile(filename, {encoding: 'utf8'}, function (err, data){
+        readFile(filename, {encoding: 'utf8'}, function (err, data){
           if (err) return callback(err);
           callback(null, engine.parse(data));
         });

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "bluebird": "^2.9.26"
+    "bluebird": "^2.9.26",
+    "fs-read-queue": "^0.1.1"
   }
 }


### PR DESCRIPTION
Queueing file reads to prevent ENFILE errors. See original PR #171 for discussion.