### PR TITLE
Don't fatal if `require.extensions` doesn't exist

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1111,16 +1111,20 @@ function reactBaseTmpl(data, options){
  *  The main render parser for React bsaed templates
  */
 function reactRenderer(type){
-
-  // Ensure JSX is transformed on require
-  if (!require.extensions['.jsx']) {
-    require.extensions['.jsx'] = requireReact;
-  }
-
-  // Supporting .react extension as well as test cases
-  // Using .react extension is not recommended.
-  if (!require.extensions['.react']) {
-    require.extensions['.react'] = requireReact;
+  
+  if (require.extensions) {
+  
+    // Ensure JSX is transformed on require
+    if (!require.extensions['.jsx']) {
+      require.extensions['.jsx'] = requireReact;
+    }
+  
+    // Supporting .react extension as well as test cases
+    // Using .react extension is not recommended.
+    if (!require.extensions['.react']) {
+      require.extensions['.react'] = requireReact;
+    }
+    
   }
 
   // Return rendering fx


### PR DESCRIPTION
Not every `require` implementation has `require.extensions` (specifically browserify doesn't).