### PR TITLE
Clear the entire cache

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -46,6 +46,7 @@ var requires = {};
  */
 
 exports.clearCache = function(){
+  readCache = {};
   cacheStore = {};
 };
 


### PR DESCRIPTION
I noticed that clearCache only clears half the cache.  It turns out that the readCache is burning me when I'm trying to clear the cache in consolidate.
