### PR TITLE
Pass express 'views' setting to nunjucks

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1034,6 +1034,8 @@ exports.nunjucks.render = function(str, options, fn) {
   return promisify(fn, function (fn) {
     try {
       var engine = requires.nunjucks || (requires.nunjucks = require('nunjucks'));
+      if (options.settings && options.settings.views) engine.configure(options.settings.views);
+
       var loader = options.loader;
       if (loader) {
         var env = new engine.Environment(new loader(options));

--- a/test/consolidate.js
+++ b/test/consolidate.js
@@ -39,6 +39,7 @@ require('./shared').test('ractive');
 require('./shared/partials').test('ractive');
 require('./shared').test('nunjucks');
 require('./shared/filters').test('nunjucks');
+require('./shared/includes').test('nunjucks');
 require('./shared').test('htmling');
 require('./shared/react').test('react');
 require('./shared').test('vash');

--- a/test/fixtures/nunjucks/_base_layout.nunjucks
+++ b/test/fixtures/nunjucks/_base_layout.nunjucks
@@ -1,0 +1,1 @@
+<header></header>{%block content%}{%endblock%}<footer></footer>

--- a/test/fixtures/nunjucks/include.nunjucks
+++ b/test/fixtures/nunjucks/include.nunjucks
@@ -1,0 +1,1 @@
+{% include 'user.nunjucks' %}

--- a/test/fixtures/nunjucks/layouts.nunjucks
+++ b/test/fixtures/nunjucks/layouts.nunjucks
@@ -1,0 +1,3 @@
+{% extends '_base_layout.nunjucks' %}
+
+{% block content %}<p>{{user.name}}</p>{% endblock %}

--- a/test/shared/includes.js
+++ b/test/shared/includes.js
@@ -11,7 +11,12 @@ exports.test = function(name) {
     it('should support includes', function(done) {
       var str = fs.readFileSync('test/fixtures/' + name + '/include.' + name).toString();
 
-      var locals = { user: user, includeDir: 'test/fixtures/' + name };
+      var viewsDir = 'test/fixtures/' + name;
+      var locals = { user: user, settings: { views: viewsDir } };
+
+      if (name === 'liquid') {
+        locals.includeDir = viewsDir;
+      }
 
       cons[name].render(str, locals, function(err, html){
         if (err) return done(err);
@@ -27,5 +32,23 @@ exports.test = function(name) {
         }
       });
     });
+
+    if (name == 'nunjucks') {
+      it('should support extending views', function (done) {
+        var str = fs.readFileSync('test/fixtures/' + name + '/layouts.' + name).toString();
+
+        var locals = {user: user, settings: {views: 'test/fixtures/' + name}};
+
+        cons[name].render(str, locals, function (err, html) {
+          if (err) return done(err);
+          try {
+            html.should.eql('<header></header><p>Tobi</p><footer></footer>');
+            return done();
+          } catch (e) {
+            return done(e);
+          }
+        });
+      });
+    }
   });
 };


### PR DESCRIPTION
Nunjucks extends doesn't work properly without #152. Its conflicted and not updated for so long time and i really like nunjucks with consolidate so here is updated version of @aroman pull request.