### PR TITLE
update：change 'read' function to sync

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1069,10 +1069,16 @@ exports.velocityjs.render = function(str, options, fn){
     try {
       options.locals = options;
       fn(null, engine.render(str, options, {
-        parse: function(file) {
+        include: function(file) {
           var filePath = options.filename;
           var includePath = filePath.slice(0, filePath.lastIndexOf('/') + 1);
           var includeFile = fs.readFileSync(path.resolve(includePath, file)).toString('utf-8');
+          
+          return this.eval(includeFile, options)
+        },
+        parse: function() {
+          var filePath = options.filename.replace(options.realpath, options.__path__);
+          var includeFile = fs.readFileSync(filePath).toString('utf-8');
           
           return this.eval(includeFile, options)
         }

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1052,6 +1052,38 @@ exports.nunjucks.render = function(str, options, fn) {
 };
 
 
+
+/**
+ * velocityjs support.
+ */
+
+exports.velocityjs = fromStringRenderer('velocityjs');
+
+/**
+ * velocityjs string support.
+ */
+
+exports.velocityjs.render = function(str, options, fn){
+  return promisify(fn, function(fn) {
+    var engine = requires.velocityjs || (requires.velocityjs = require('velocityjs'));
+    try {
+      options.locals = options;
+      fn(null, engine.render(str, options, {
+        parse: function(file) {
+          var filePath = options.filename;
+          var includePath = filePath.slice(0, filePath.lastIndexOf('/') + 1);
+          var includeFile = fs.readFileSync(path.resolve(includePath, file));
+          
+          return this.eval(includeFile, options)
+        }
+      }).trimLeft());
+    } catch (err) {
+      fn(err);
+    }
+  });
+};
+
+
 /**
  * HTMLing support.
  */

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1072,7 +1072,7 @@ exports.velocityjs.render = function(str, options, fn){
         parse: function(file) {
           var filePath = options.filename;
           var includePath = filePath.slice(0, filePath.lastIndexOf('/') + 1);
-          var includeFile = fs.readFileSync(path.resolve(includePath, file));
+          var includeFile = fs.readFileSync(path.resolve(includePath, file)).toString('utf-8');
           
           return this.eval(includeFile, options)
         }

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -89,14 +89,18 @@ function read(path, options, fn) {
   // cached (only if cached is a string and not a compiled template function)
   if (cached) return fn(null, str);
 
-  // read
-  fs.readFile(path, 'utf8', function(err, str){
-    if (err) return fn(err);
+  try{
+    // read file sync
+    var str = fs.readFileSync(path, 'utf8');
+
     // remove extraneous utf8 BOM marker
     str = str.replace(/^\uFEFF/, '');
     if (options.cache) readCache[path] = str;
+
     fn(null, str);
-  });
+  }catch(err){
+    return fn(err);
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "consolidate",
+  "name": "consolidate-velocity",
   "version": "0.14.0",
   "description": "Template engine consolidation library",
   "keywords": [
@@ -59,6 +59,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "bluebird": "^3.1.1"
+    "bluebird": "^3.1.1",
+    "velocityjs": "^0.8.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consolidate-velocity",
-  "version": "0.14.0",
+  "version": "0.14.2",
   "description": "Template engine consolidation library",
   "keywords": [
     "template",


### PR DESCRIPTION
when I use koa-generator (koa2 -e) to generate `koa@next`/`ejs` project, 
I found the ejs template can't parse correctly :  https://github.com/base-n/koa-generator/issues/6 .

so I think that `read` function is a atom function (`fs.readFile`), so that can be changed to sync funtion(`readFileSync`).
