### PR TITLE
Change instance to render components on the server

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1149,6 +1149,7 @@ function reactRenderer(type){
     return promisify(fn, function(fn) {
       // React Import
       var engine = requires.react || (requires.react = require('react'));
+      var ReactDOMServer = require('react-dom/server');
 
       // Assign HTML Base
       var base = options.base;
@@ -1180,7 +1181,7 @@ function reactRenderer(type){
         }
 
         parsed = new Factory(options);
-        content = (isNonStatic) ? engine.renderToString(parsed) : engine.renderToStaticMarkup(parsed);
+        content = (isNonStatic) ? ReactDOMServer.renderToString(parsed) : ReactDOMServer.renderToStaticMarkup(parsed);
 
         if (base){
           baseStr = readCache[str] || fs.readFileSync(resolve(base), 'utf8');


### PR DESCRIPTION
Methods React.renderToString and React.renderToStaticMarkup are depecrated from React instance, we must use ReactDOMServer.renderToString and ReactDOMServer.renderToStaticMarkup instead of them since React v0.14

See: https://facebook.github.io/react/docs/top-level-api.html#reactdomserver
