### PR TITLE
Update ejs info

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@
   - [dustjs-linkedin (maintained fork of dust)](https://github.com/linkedin/dustjs) [(website)](http://linkedin.github.io/dustjs/)
   - [eco](https://github.com/sstephenson/eco)
   - [ect](https://github.com/baryshev/ect) [(website)](http://ectjs.com/)
-  - [ejs](https://github.com/visionmedia/ejs)
+  - [ejs](https://github.com/mde/ejs) [(website)](http://ejs.co/)
   - [haml](https://github.com/visionmedia/haml.js)
   - [haml-coffee](https://github.com/9elements/haml-coffee)
   - [hamlet](https://github.com/gregwebs/hamlet.js)


### PR DESCRIPTION
I am a collaborator at EJS.

EJS v2+ is developed at https://github.com/mde/ejs. We also now have a website: http://ejs.co/.

This PR updates the links for EJS.