### PR TITLE
Mark SWIG as unmaintained in the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@
   - [ractive](https://github.com/Rich-Harris/Ractive)
   - [react](https://github.com/facebook/react)
   - [slm](https://github.com/slm-lang/slm)
-  - [swig](https://github.com/paularmstrong/swig) [(website)](http://paularmstrong.github.com/swig/)
+  - [swig (unmaintained)](https://github.com/paularmstrong/swig)
   - [templayed](http://archan937.github.com/templayed.js/)
   - [twig](https://github.com/justjohn/twig.js)
   - [liquid](https://github.com/leizongmin/tinyliquid) [(website)](http://liquidmarkup.org/)


### PR DESCRIPTION
SWIG appears to be unmaintained, and the link to the website returns 404.
