### PR TITLE
Improve Marko Implementation (support v4 & handle cached templates)

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1452,7 +1452,7 @@ exports.marko = function(path, options, fn){
 
     try {
       var tmpl = cache(options) || cache(options, engine.load(path, options));
-      tmpl.render(options, fn)
+      tmpl.renderToString(options, fn)
     } catch (err) {
       fn(err);
     }
@@ -1470,7 +1470,7 @@ exports.marko.render = function(str, options, fn) {
 
     try {
       var tmpl = cache(options) || cache(options, engine.load('string.marko', str, options));
-      tmpl.render(options, fn)
+      tmpl.renderToString(options, fn)
     } catch (err) {
       fn(err);
     }

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1467,9 +1467,10 @@ exports.marko.render = function(str, options, fn) {
   return promisify(fn, function (fn) {
     var engine = requires.marko || (requires.marko = require('marko'));
     options.writeToDisk = !!options.cache;
+    options.filename = options.filename || 'string.marko';
 
     try {
-      var tmpl = cache(options) || cache(options, engine.load('string.marko', str, options));
+      var tmpl = cache(options) || cache(options, engine.load(options.filename, str, options));
       tmpl.renderToString(options, fn)
     } catch (err) {
       fn(err);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "atpl": ">=0.7.6",
     "babel-core": "^6.7.6",
     "babel-preset-react": "^6.5.0",
-    "bracket-template": "^1.0.3",
+    "bracket-template": "^1.1.4",
     "dot": "^1.0.1",
     "dust": "^0.3.0",
     "dustjs-helpers": "^1.1.1",


### PR DESCRIPTION
Marko changed its implementation and thus "The render callback will no longer receive a string in Marko v4. Use `renderToString(data, callback)` instead" See https://github.com/marko-js/marko/pull/450.

This change is compatible with the current stable public version.