### PR TITLE
Passing in template name to dust compile.

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -383,7 +383,12 @@ exports.dust.render = function(str, options, fn){
     };
 
     try {
-      var tmpl = cache(options) || cache(options, engine.compileFn(str));
+      var templateName;
+      if (options.filename) {
+        templateName = options.filename.replace(new RegExp('^' + views + '/'), '').replace(new RegExp('\\.' + ext), '');
+      }
+
+      var tmpl = cache(options) || cache(options, engine.compileFn(str, templateName));
       tmpl(options, fn);
     } catch (err) {
       fn(err);

--- a/test/consolidate.js
+++ b/test/consolidate.js
@@ -19,6 +19,7 @@ require('./shared').test('hogan');
 require('./shared/partials').test('hogan');
 require('./shared').test('dust');
 require('./shared/partials').test('dust');
+require('./shared/dust').test('dust');
 require('./shared').test('handlebars');
 require('./shared/partials').test('handlebars');
 require('./shared/helpers').test('handlebars');

--- a/test/fixtures/dust/user_template_name.dust
+++ b/test/fixtures/dust/user_template_name.dust
@@ -1,0 +1,2 @@
+<p>{user.name}</p>
+{@templateName/}

--- a/test/shared/dust.js
+++ b/test/shared/dust.js
@@ -1,0 +1,38 @@
+/*eslint-env node, mocha */
+var cons = require('../../');
+var fs = require('fs');
+
+// var should = require('should');
+
+exports.test = function(name) {
+  var user = { name: 'Tobi' };
+
+  describe(name, function(){
+    // Use case: return upper case string.
+    it('should support fetching template name from the context', function(done) {
+      var viewsDir = 'test/fixtures/' + name;
+      var templatePath = viewsDir + '/user_template_name.' + name;
+      var str = fs.readFileSync(templatePath).toString();
+
+      var locals = {
+        user: user,
+        views: viewsDir,
+        filename: templatePath
+      };
+
+      if (name === 'dust') {
+        var dust = require('dustjs-helpers');
+        dust.helpers.templateName = function(chunk, context, bodies, params) {
+          return chunk.write(context.getTemplateName());
+        };
+        cons.requires.dust = dust;
+      }
+
+      cons[name].render(str, locals, function(err, html){
+        if (err) return done(err);
+        html.should.eql('<p>Tobi</p>user_template_name');
+        return done();
+      });
+    });
+  });
+};


### PR DESCRIPTION
This will ensure when context.getTemplateName is called in a base template the appropriate name is available.

Docs for dust helper API can be found here: http://www.dustjs.com/docs/helper-api/