### PR TITLE
Use native Promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ node_js:
   - "5"
   - "4"
   - "0.12"
-  - "0.10"
 matrix:
   fast_finish: true
   allow_failures:
-    - node_js: "0.10"
     - node_js: "0.12"

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -16,7 +16,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var Promise = require('bluebird');
+var utilPromisify = require('util.promisify');
 
 var join = path.join;
 var resolve = path.resolve;
@@ -134,15 +134,11 @@ function readPartials(path, options, fn) {
  * promisify
  */
 function promisify(fn, exec) {
-  return new Promise(function (res, rej) {
-    fn = fn || function (err, html) {
-      if (err) {
-        return rej(err);
-      }
-      res(html);
-    };
+  if (fn) {
     exec(fn);
-  });
+  } else {
+    return utilPromisify(exec)();
+  }
 }
 
 
@@ -1364,7 +1360,7 @@ exports['arc-templates'] = fromStringRenderer('arc-templates');
  */
 
 exports['arc-templates'].render = function(str, options, fn) {
-  var readFileWithOptions = Promise.promisify(read);
+  var readFileWithOptions = utilPromisify(read);
   var consolidateFileSystem = {};
   consolidateFileSystem.readFile = function (path) {
     return readFileWithOptions(path, options);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.14.5",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "dependencies": {
-    "bluebird": "^3.1.1"
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "arc-templates": "^0.5.1",


### PR DESCRIPTION
Fixes #293.

- Replaces Bluebird (a relatively large dependency) with native Promises, resulting in better standard support and likely performance.
- Uses a shim for Node 8's `require('util').promisify` which supports custom Promises. This shim can be replaced with the native function after all Node versions before 8 are unmaintained (April 2019).
- Simplifies our `promisify` function (which promisifies if a callback is not given) by using `util.promisify` internally.
- Our `promisify` now returns nothing (instead of a malformed Promise which does not reject or resolve) when given a callback.
- Stops testing Node 0.10, which is no longer in LTS anyway, because it doesn't support Promises.