### PR TITLE
Add support for HTMLC

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1702,6 +1702,29 @@ exports.teacup.render = function(str, options, fn){
 }
 
 /**
+ * HTMLC support.
+ */
+
+exports.htmlc = fromStringRenderer('htmlc');
+
+/**
+ * HTMLC string support.
+ */
+
+exports.htmlc.render = function(str, options, fn) {
+  return promisify(fn, function(fn) {
+    var engine = requires.htmlc || (requires.htmlc = require('htmlc'));
+    try {
+      var tmpl = cache(options) || cache(options, engine.template(str, null, options));
+      fn(null, tmpl(options).replace(/\n$/, ''));
+    } catch (err) {
+      fn(err);
+    }
+  });
+};
+
+
+/**
  * expose the instance of the engine
  */
  exports.requires = requires;


### PR DESCRIPTION
HTMLC is a preprocessor that allows users to write css ID's & classes using '#' or '.' for example: `<div#head>Lorem</div#head> --changed to--> <div id='head'>Lorem</div>`

My motivation for adding this is because vue-loader (from the Vue.js framework) uses consolidate.js for preprocessing html templates. It is very convenient to be able to set ' lang="htmlc" ' at the top of a .vue file (which is processed by vue-loader into html/css), then be able to write htmlc like a rockstar.