### PR TITLE
Fix React deprecation warning in test

### DIFF
--- a/test/fixtures/react/user.react
+++ b/test/fixtures/react/user.react
@@ -1,13 +1,15 @@
+"use strict";
+
 var React = require('react');
 
-var User = React.createClass({
-  render: function() {
+class User extends React.Component {
+  render() {
     return (
       <p>
         {this.props.user.name}
       </p>
     );
   }
-});
+};
 
 module.exports = User;


### PR DESCRIPTION
React emitted this deprecation warning while running the tests: 

> Warning: Accessing `createClass` via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class

I replaced `React.createClass` with a plain javascript class in the fixture to future-proof your tests.