### PR TITLE
Use `allowInlineIncludes` and `path` option for twig engine

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -619,7 +619,9 @@ exports.twig.render = function(str, options, cb) {
   return promisify(cb, function(cb) {
     var engine = requires.twig || (requires.twig = require('twig').twig);
     var templateData = {
-      data: str
+      data: str,
+      allowInlineIncludes: options.allowInlineIncludes,
+      path: options.path
     };
     try {
       var tmpl = cache(templateData) || cache(templateData, engine(templateData));


### PR DESCRIPTION
Twig allows to include partials. Unfortunately this is possible at the moment when using `consolidate`, since it doesn't pass the options `allowInlineIncludes` and `path` to `twig.js`.