### PR TITLE
Add velocityjs to readme.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,7 @@
   - [twig](https://github.com/justjohn/twig.js)
   - [underscore](https://github.com/documentcloud/underscore) [(website)](http://underscorejs.org/#template)
   - [vash](https://github.com/kirbysayshi/vash)
+  - [velocityjs](https://github.com/julianshapiro/velocity) [(website)](http://velocityjs.org/)
   - [walrus](https://github.com/jeremyruppel/walrus) [(website)](http://documentup.com/jeremyruppel/walrus/)
   - [whiskers](https://github.com/gsf/whiskers.js)
 


### PR DESCRIPTION
Velocity.js support was added in https://github.com/tj/consolidate.js/commit/e223a27d6b83e91bfae1c9f5497e45549eecd1b4, but wasn't included in the readme.