### PR TITLE
Fix mustache support

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1104,7 +1104,7 @@ exports.mustache.render = function(str, options, cb) {
   return promisify(cb, function(cb) {
     var engine = requires.mustache || (requires.mustache = require('mustache'));
     try {
-      cb(null, engine.to_html(str, options, options.partials));
+      cb(null, engine.render(str, options, options.partials));
     } catch (err) {
       cb(err);
     }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "marko": "^3.12.0",
     "mocha": "^3.1.2",
     "mote": "^0.2.0",
-    "mustache": "^2.2.1",
+    "mustache": "^4.0.0",
     "nunjucks": "^3.0.0",
     "plates": "~0.4.8",
     "pug": "^2.0.0-beta6",


### PR DESCRIPTION
Use `mustache.render()` instead of `mustache.to_html()` that got removed as of `mustache` v4 (https://github.com/janl/mustache.js/pull/735).

This closes #331 