### PR TITLE
Use `namespaces` option for twig engine

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -674,6 +674,7 @@ exports.twig.render = function(str, options, cb) {
     var templateData = {
       data: str,
       allowInlineIncludes: options.allowInlineIncludes,
+      namespaces: options.namespaces,
       path: options.path
     };
     try {


### PR DESCRIPTION
Hey!

At the moment, using namespaces with `twig.js` is not possible, because the option `namespaces` is not passed to the render function.

See also: https://github.com/twigjs/twig.js/wiki#namespaces