### PR TITLE
Fixed issues with twing support

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1778,7 +1778,7 @@ exports.twing.render = function(str, options, cb) {
       //Were we given the root twing object and need to setup the TwingEnvironment?
       if(engine.hasOwnProperty("TwingEnvironment")) {
         var loader = new engine.TwingLoaderNull();
-        if(options.settings && options.settings.views && fs.existsSync(options.settings.views){
+        if(options.settings && options.settings.views && fs.existsSync(options.settings.views)){
           loader = new engine.TwingLoaderFilesystem(options.settings.views);
         }
         engine = requires.twing = new engine.TwingEnvironment(loader);

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1776,9 +1776,9 @@ exports.twing.render = function(str, options, cb) {
     var engine = requires.twing || (requires.twing = require('twing'));
     try {
       //Were we given the root twing object and need to setup the TwingEnvironment?
-      if(engine.hasOwnProperty("TwingEnvironment")) {
+      if (engine.hasOwnProperty('TwingEnvironment')) {
         var loader = new engine.TwingLoaderNull();
-        if(options.settings && options.settings.views && fs.existsSync(options.settings.views)){
+        if (options.settings && options.settings.views && fs.existsSync(options.settings.views)) {
           loader = new engine.TwingLoaderFilesystem(options.settings.views);
         }
         engine = requires.twing = new engine.TwingEnvironment(loader);

--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1769,13 +1769,21 @@ exports.twing = fromStringRenderer('twing');
 
 /**
  * Twing string support.
- */ 
+ */
 
 exports.twing.render = function(str, options, cb) {
   return promisify(cb, function(cb) {
     var engine = requires.twing || (requires.twing = require('twing'));
     try {
-      new engine.TwingEnvironment(new engine.TwingLoaderNull()).createTemplate(str).then((twingTemplate) => {
+      //Were we given the root twing object and need to setup the TwingEnvironment?
+      if(engine.hasOwnProperty("TwingEnvironment")) {
+        var loader = new engine.TwingLoaderNull();
+        if(options.settings && options.settings.views && fs.existsSync(options.settings.views){
+          loader = new engine.TwingLoaderFilesystem(options.settings.views);
+        }
+        engine = requires.twing = new engine.TwingEnvironment(loader);
+      }
+      engine.createTemplate(str).then((twingTemplate) => {
         twingTemplate.render(options).then((rendTmpl) => {
           var tmpl = cache(options) || cache(options, rendTmpl);
           cb(null, tmpl);


### PR DESCRIPTION
This PR does two things.

First allows twigs to include other twigs by using the TwingFilesystemLoader if options.settings.views is present and valid.  
Second fixes #329 by allowing a pre-setup TwingEnvironment to get passed in through consolidate's requires.twing