### PR TITLE
Handle multiple views folder for dustjs partials

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -507,8 +507,25 @@ exports.dust.render = function(str, options, cb) {
 
     engine.onLoad = function(path, callback) {
       if (extname(path) === '') path += '.' + ext;
-      if (path[0] !== '/') path = views + '/' + path;
-      read(path, options, callback);
+      // In case of array given in app.set('views', [])
+      if(Array.isArray(views)){
+        var existingPath = [];
+        for (var i = 0; i < views.length; i++)
+          if (fs.existsSync(views[i] + '/' + path))
+            existingPath.push(views[i] + '/' + path);
+
+        if(existingPath.length == 0)
+          throw new Error('Cannot find template: ' + path);
+        else if(existingPath.length > 1) {
+          console.warn('Multiple file with the same name:\n' + existingPath.join('\n') + '\nDefault using => ' +  existingPath[0]);
+          read(existingPath[0], options, callback);
+        } else {
+          read(existingPath[0], options, callback);
+        }
+      } else {
+        if (path[0] !== '/') path = views + '/' + path;
+        read(path, options, callback);
+      }
     };
 
     try {


### PR DESCRIPTION
Hello,

we are in a situation where we have .dust file in two different location.
So we set on express 2 different views folder like this: app.set('views', [folder1, folder2]);

But Dustjs is not enable to check correctly in both folder with partials ( {>myFile.dust} )
The array of folder is stringify and dust js throw an error.

The objectif is to handle the case that there is multiple views folder and manage to find the file correctly.

Btw if the file is in both directory I added a warning and the first file found is used by default.