### PR TITLE
fix: add undeclared optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,222 @@
     "walrus": "^0.10.1",
     "whiskers": "^0.4.0"
   },
+  "peerDependencies": {
+    "velocityjs": "^2.0.1",
+    "tinyliquid": "^0.2.34",
+    "liquid-node": "^3.0.1",
+    "jade": "^1.11.0",
+    "then-jade": "*",
+    "dust": "^0.3.0",
+    "dustjs-helpers": "^1.7.4",
+    "dustjs-linkedin": "^2.7.5",
+    "swig": "^1.4.2",
+    "swig-templates": "^2.0.3",
+    "razor-tmpl": "^1.3.1",
+    "atpl": ">=0.7.6",
+    "liquor": "^0.0.5",
+    "twig": "^1.15.2",
+    "ejs": "^3.1.5",
+    "eco": "^1.1.0-rc-3",
+    "jazz": "^0.0.18",
+    "jqtpl": "~1.1.0",
+    "hamljs": "^0.6.2",
+    "hamlet": "^0.3.3",
+    "whiskers": "^0.4.0",
+    "haml-coffee": "^1.14.1",
+    "hogan.js": "^3.0.2",
+    "templayed": ">=0.2.3",
+    "handlebars": "^4.7.6",
+    "underscore": "^1.11.0",
+    "lodash": "^4.17.20",
+    "pug": "^3.0.0",
+    "then-pug": "*",
+    "qejs": "^3.0.5",
+    "walrus": "^0.10.1",
+    "mustache": "^4.0.1",
+    "just": "^0.1.8",
+    "ect": "^0.5.9",
+    "mote": "^0.2.0",
+    "toffee": "^0.3.6",
+    "dot": "^1.1.3",
+    "bracket-template": "^1.1.5",
+    "ractive": "^1.3.12",
+    "nunjucks": "^3.2.2",
+    "htmling": "^0.0.8",
+    "babel-core": "^6.26.3",
+    "plates": "~0.4.11",
+    "react-dom": "^16.13.1",
+    "react": "^16.13.1",
+    "arc-templates": "^0.5.3",
+    "vash": "^0.13.0",
+    "slm": "^2.0.0",
+    "marko": "^3.14.4",
+    "teacup": "^2.0.0",
+    "coffee-script": "^1.12.7",
+    "squirrelly": "^5.1.0",
+    "twing": "^5.0.2"
+  },
+  "peerDependenciesMeta": {
+    "velocityjs": {
+      "optional": true
+    },
+    "tinyliquid": {
+      "optional": true
+    },
+    "liquid-node": {
+      "optional": true
+    },
+    "jade": {
+      "optional": true
+    },
+    "then-jade": {
+      "optional": true
+    },
+    "dust": {
+      "optional": true
+    },
+    "dustjs-helpers": {
+      "optional": true
+    },
+    "dustjs-linkedin": {
+      "optional": true
+    },
+    "swig": {
+      "optional": true
+    },
+    "swig-templates": {
+      "optional": true
+    },
+    "razor-tmpl": {
+      "optional": true
+    },
+    "atpl": {
+      "optional": true
+    },
+    "liquor": {
+      "optional": true
+    },
+    "twig": {
+      "optional": true
+    },
+    "ejs": {
+      "optional": true
+    },
+    "eco": {
+      "optional": true
+    },
+    "jazz": {
+      "optional": true
+    },
+    "jqtpl": {
+      "optional": true
+    },
+    "hamljs": {
+      "optional": true
+    },
+    "hamlet": {
+      "optional": true
+    },
+    "whiskers": {
+      "optional": true
+    },
+    "haml-coffee": {
+      "optional": true
+    },
+    "hogan.js": {
+      "optional": true
+    },
+    "templayed": {
+      "optional": true
+    },
+    "handlebars": {
+      "optional": true
+    },
+    "underscore": {
+      "optional": true
+    },
+    "lodash": {
+      "optional": true
+    },
+    "pug": {
+      "optional": true
+    },
+    "then-pug": {
+      "optional": true
+    },
+    "qejs": {
+      "optional": true
+    },
+    "walrus": {
+      "optional": true
+    },
+    "mustache": {
+      "optional": true
+    },
+    "just": {
+      "optional": true
+    },
+    "ect": {
+      "optional": true
+    },
+    "mote": {
+      "optional": true
+    },
+    "toffee": {
+      "optional": true
+    },
+    "dot": {
+      "optional": true
+    },
+    "bracket-template": {
+      "optional": true
+    },
+    "ractive": {
+      "optional": true
+    },
+    "nunjucks": {
+      "optional": true
+    },
+    "htmling": {
+      "optional": true
+    },
+    "babel-core": {
+      "optional": true
+    },
+    "plates": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "arc-templates": {
+      "optional": true
+    },
+    "vash": {
+      "optional": true
+    },
+    "slm": {
+      "optional": true
+    },
+    "marko": {
+      "optional": true
+    },
+    "teacup": {
+      "optional": true
+    },
+    "coffee-script": {
+      "optional": true
+    },
+    "squirrelly": {
+      "optional": true
+    },
+    "twing": {
+      "optional": true
+    }
+  },
   "keywords": [
     "engine",
     "template",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`consolidate` has some undeclared optional peer dependencies causing it to rely on hoisting to be in its favour which is not guaranteed.
https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies

**How did you fix it?**

Add all undeclared dependencies as optional peer dependencies, using the ranges from `devDependencies`