### PR TITLE
Correct documentation for nunjucks FileSystemLoader usage

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -1353,11 +1353,22 @@ exports.nunjucks.render = function(str, options, cb) {
       //
       // because `renderString` does not initiate loaders
       // we must manually create a loader for it based off
-      // either `options.settings.views` or `options.nunjucks` or `options.nunjucks.root`
+      // either `options.settings.views` or `options.nunjucks.loader`
       //
       // <https://github.com/mozilla/nunjucks/issues/730>
       // <https://github.com/crocodilejs/node-email-templates/issues/182>
       //
+      // `options.nunjucks.loader` can either be a single search path for
+      // or an array of arguments to be passed to `FileSystemLoader()`.
+      //
+      // For a single search path:
+      //    `options.nunjucks.loader = 'path/to/templates/root'`
+      //
+      // For multiple search paths:
+      //    `options.nunjucks.loader = [ ['search/path/a', 'search/path/b'], {} ]`
+      //
+      // To pass options to `FileSystemLoader()`:
+      //    `options.nunjucks.loader = [ 'path/to/templates/root', { noCache: true } ]`
 
       // so instead we simply check if we passed a custom loader
       // otherwise we create a simple file based loader


### PR DESCRIPTION
The comments documenting how [`nunjucks.FileSystemLoader`](https://mozilla.github.io/nunjucks/api.html#filesystemloader) is instantiated describe the use of `options.nunjucks.root` which isn't actually used to set up the loader.

This PR removes the error in the documentation and expands the comments to describe how to address both ways that `options.nunjucks.loader` can be used to pass arguments to `nunjucks.FileSystemLoader`.